### PR TITLE
Provide detail and unit test of Decimal exception behavior

### DIFF
--- a/Sources/Test/DecimalTest.cpp
+++ b/Sources/Test/DecimalTest.cpp
@@ -30,6 +30,11 @@ TEST(StringUtilitiesTest, Decimal_convert_string_with_leading_trailing_zeros)
     EXPECT_EQ("0.00403", decimal.str());
 }
 
+TEST(StringUtilitiesTest, Decimal_convert_non_numeric_string_exception)
+{
+    EXPECT_THROW(Decimal("Alpha_Only_String"), std::invalid_argument);
+}
+
 TEST(StringUtilitiesTest, Decimal_convert_integer)
 {
     Decimal decimal("576");

--- a/Sources/Utilities/Decimal.h
+++ b/Sources/Utilities/Decimal.h
@@ -8,6 +8,8 @@
  * @brief Provides a type for decimal values which can be converted to/from string representation and supports
  * summation and comparison while maintaining precision.
  *
+ * @throws Exception if string cannot be converted to a decimal representation.
+ *
  */
 class Decimal
 {
@@ -56,6 +58,8 @@ class Decimal
      * @brief Converts a string to a Decimal represtentation (significant_digits and exponent).
      *
      * @param number String representing a numeric value.
+     *
+     * @throws invalid_argument exception (received from std::stoi) if unable to convert to numeric value.
      */
     void string_to_decimal(std::string number);
 


### PR DESCRIPTION
The Decimal class does not protect against exceptions thrown internally by `std::stoi`, which is why the Utilities helper function `is_number()` should be used before converting strings.

This PR just documents this better for the Decimal class and adds a demonstrating unit test.