### PR TITLE
UdpSocket add multicast support

### DIFF
--- a/Sources/Test/UdpSocketTest.cpp
+++ b/Sources/Test/UdpSocketTest.cpp
@@ -25,7 +25,8 @@ TEST(UdpSocketTest, invalid_multicast_ip_addr)
 
 TEST(UdpSocketTest, multicast_port_builds)
 {
-    UdpSocket second_receiver_socket("0.0.0.0", "5010", "7778", "239.255.50.10");
+    // Test that no errors occur when connecting to multicast group.
+    UdpSocket multicast_subscriber_socket("0.0.0.0", "5010", "7778", "239.255.50.10");
 }
 
 class UdpSocketTestFixture : public ::testing::Test
@@ -40,7 +41,6 @@ class UdpSocketTestFixture : public ::testing::Test
     UdpSocket receiver_socket;
     static inline std::string common_port = "1789";
     static inline std::string ip_address = "127.0.0.1";
-    // static inline std::string ip_address = "239.255.50.10";
 };
 
 TEST_F(UdpSocketTestFixture, send_and_receive)

--- a/Sources/Test/UdpSocketTest.cpp
+++ b/Sources/Test/UdpSocketTest.cpp
@@ -18,6 +18,16 @@ TEST(UdpSocketTest, invalid_connection_ip_addr_settings)
     EXPECT_THROW(UdpSocket dcs_socket("127001", "1908", "1909"), std::runtime_error);
 }
 
+TEST(UdpSocketTest, invalid_multicast_ip_addr)
+{
+    EXPECT_THROW(UdpSocket second_receiver_socket("0.0.0.0", "5015", "7778", "23813222"), std::runtime_error);
+}
+
+TEST(UdpSocketTest, multicast_port_builds)
+{
+    UdpSocket second_receiver_socket("0.0.0.0", "5010", "7778", "239.255.50.10");
+}
+
 class UdpSocketTestFixture : public ::testing::Test
 {
   public:
@@ -30,6 +40,7 @@ class UdpSocketTestFixture : public ::testing::Test
     UdpSocket receiver_socket;
     static inline std::string common_port = "1789";
     static inline std::string ip_address = "127.0.0.1";
+    // static inline std::string ip_address = "239.255.50.10";
 };
 
 TEST_F(UdpSocketTestFixture, send_and_receive)
@@ -38,12 +49,6 @@ TEST_F(UdpSocketTestFixture, send_and_receive)
     sender_socket.send(test_message);
     std::stringstream ss_received = receiver_socket.receive();
     EXPECT_EQ(ss_received.str(), test_message);
-}
-
-TEST_F(UdpSocketTestFixture, unavailable_port_bind)
-{
-    // Expect exception thrown if try to bind a new socket to same rx_port.
-    EXPECT_THROW(UdpSocket duplicate_socket(ip_address, common_port, "1801"), std::runtime_error);
 }
 
 TEST_F(UdpSocketTestFixture, receive_timeout)

--- a/Sources/Utilities/UdpSocket.cpp
+++ b/Sources/Utilities/UdpSocket.cpp
@@ -80,7 +80,7 @@ UdpSocket::UdpSocket(const std::string &ip_address,
         ip_mreq mreq;
         const std::wstring multicast_addr_L = std::wstring(multicast_addr.begin(), multicast_addr.end());
         InetPton(AF_INET, multicast_addr_L.c_str(), &mreq.imr_multiaddr.s_addr);
-        mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+        mreq.imr_interface.s_addr = htonl(std::stoi(ip_address));
         result = setsockopt(socket_id_, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mreq, sizeof(mreq));
         if (result != 0) {
             const std::string error_msg = "Failure in setting Multicast membership in socket options -- WSA Error: " +

--- a/Sources/Utilities/UdpSocket.cpp
+++ b/Sources/Utilities/UdpSocket.cpp
@@ -11,7 +11,10 @@
 // Set default timeout for socket.
 DWORD socket_timeout_ms = 100;
 
-UdpSocket::UdpSocket(const std::string &ip_address, const std::string &rx_port, const std::string &tx_port)
+UdpSocket::UdpSocket(const std::string &ip_address,
+                     const std::string &rx_port,
+                     const std::string &tx_port,
+                     const std::string &multicast_addr)
 {
     // Detect any missing input settings.
     if (rx_port.empty() || tx_port.empty() || ip_address.empty()) {
@@ -38,8 +41,8 @@ UdpSocket::UdpSocket(const std::string &ip_address, const std::string &rx_port, 
 
     // Define local receive port.
     addrinfo *local_port;
-    const auto getaddr_result = getaddrinfo(ip_address.c_str(), rx_port.c_str(), &hints, &local_port);
-    if (getaddr_result != 0) {
+    auto result = getaddrinfo(ip_address.c_str(), rx_port.c_str(), &hints, &local_port);
+    if (result != 0) {
         const std::string error_msg = "Could not get valid address info from requested IP: " + ip_address +
                                       " Rx_Port: " + rx_port + " Tx_Port: " + tx_port +
                                       " -- WSA Error: " + std::to_string(WSAGetLastError());
@@ -47,18 +50,44 @@ UdpSocket::UdpSocket(const std::string &ip_address, const std::string &rx_port, 
         throw std::runtime_error(error_msg);
     }
 
-    // Bind local socket to receive port.
     socket_id_ = socket(local_port->ai_family, local_port->ai_socktype, local_port->ai_protocol);
-    setsockopt(socket_id_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&socket_timeout_ms, sizeof(socket_timeout_ms));
-    const auto bind_result = bind(socket_id_, local_port->ai_addr, static_cast<int>(local_port->ai_addrlen));
-    freeaddrinfo(local_port);
 
-    if (bind_result == SOCKET_ERROR) {
+    // Socket options: allow reuse of address, and set timeout.
+    const u_int yes = 1;
+    result = setsockopt(socket_id_, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(yes));
+    result =
+        result ||
+        setsockopt(socket_id_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&socket_timeout_ms, sizeof(socket_timeout_ms));
+    if (result != 0) {
+        const std::string error_msg =
+            "Failure in setting socket options -- WSA Error: " + std::to_string(WSAGetLastError());
+        WSACleanup();
+        throw std::runtime_error(error_msg);
+    }
+
+    // Bind local socket to receive port.
+    result = bind(socket_id_, local_port->ai_addr, static_cast<int>(local_port->ai_addrlen));
+    freeaddrinfo(local_port);
+    if (result != 0) {
         const std::string error_msg =
             "Could not bind UDP address to socket -- WSA Error: " + std::to_string(WSAGetLastError());
         closesocket(socket_id_);
         WSACleanup();
         throw std::runtime_error(error_msg);
+    }
+
+    if (!multicast_addr.empty()) {
+        ip_mreq mreq;
+        const std::wstring multicast_addr_L = std::wstring(multicast_addr.begin(), multicast_addr.end());
+        InetPton(AF_INET, multicast_addr_L.c_str(), &mreq.imr_multiaddr.s_addr);
+        mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+        result = setsockopt(socket_id_, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *)&mreq, sizeof(mreq));
+        if (result != 0) {
+            const std::string error_msg = "Failure in setting Multicast membership in socket options -- WSA Error: " +
+                                          std::to_string(WSAGetLastError());
+            WSACleanup();
+            throw std::runtime_error(error_msg);
+        }
     }
 
     if (tx_port != "dynamic") {

--- a/Sources/Utilities/UdpSocket.h
+++ b/Sources/Utilities/UdpSocket.h
@@ -13,11 +13,15 @@ class UdpSocket
      * @brief Construct a new Dcs Socket object bound to the rx port and initializes the destination address using the
      * tx port if provided, or determines tx_port address dynamically if not.
      *
-     * @param tx_ip_address UDP transmit IP address.
+     * @param ip_address UDP receive/transmit IP address.
      * @param rx_port UDP receive port.
      * @param tx_port UDP transmit port, defaults to dynamic (use recvfrom address) if not provided.
+     * @param multicast_addr Address to join multicast group on, not set if no address provided.
      */
-    UdpSocket(const std::string &ip_address, const std::string &rx_port, const std::string &tx_port = "dynamic");
+    UdpSocket(const std::string &ip_address,
+              const std::string &rx_port,
+              const std::string &tx_port = "dynamic",
+              const std::string &multicast_addr = "");
 
     /**
      * @brief Destroy the Dcs Socket object


### PR DESCRIPTION
DCS-BIOS uses multicast to publish statuses over UDP. This PR enables that functionality within the UdpSocket class as a start for #41