### PR TITLE
Add comparison monitor class

### DIFF
--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
@@ -32,7 +32,7 @@ void ComparisonMonitor::update_settings(const json &settings)
     }
 }
 
-std::optional<int> ComparisonMonitor::determineContextState(DcsInterface &dcs_interface)
+int ComparisonMonitor::determineContextState(DcsInterface &dcs_interface)
 {
     if (settings_are_filled_) {
         const auto maybe_current_game_value = dcs_interface.get_decimal_of_dcs_id(dcs_id_compare_monitor_);
@@ -40,7 +40,7 @@ std::optional<int> ComparisonMonitor::determineContextState(DcsInterface &dcs_in
             return comparison_is_satisfied(maybe_current_game_value.value()) ? 1 : 0;
         }
     }
-    return std::nullopt;
+    return 0;
 }
 
 bool ComparisonMonitor::comparison_is_satisfied(Decimal current_game_value)

--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
@@ -32,7 +32,7 @@ void ComparisonMonitor::update_settings(const json &settings)
     }
 }
 
-int ComparisonMonitor::determineContextState(DcsInterface &dcs_interface)
+int ComparisonMonitor::determineContextState(DcsInterface &dcs_interface) const
 {
     if (settings_are_filled_) {
         const auto maybe_current_game_value = dcs_interface.get_decimal_of_dcs_id(dcs_id_compare_monitor_);
@@ -43,7 +43,7 @@ int ComparisonMonitor::determineContextState(DcsInterface &dcs_interface)
     return 0;
 }
 
-bool ComparisonMonitor::comparison_is_satisfied(Decimal current_game_value)
+bool ComparisonMonitor::comparison_is_satisfied(Decimal current_game_value) const
 {
     bool comparison_result = false;
     switch (dcs_id_compare_condition_) {

--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.cpp
@@ -1,0 +1,61 @@
+// Copyright 2021 Charles Tytler
+
+#include "pch.h"
+
+#include "../../Utilities/StringUtilities.h"
+#include "ComparisonMonitor.h"
+
+ComparisonMonitor::ComparisonMonitor(const json &settings) { update_settings(settings); }
+
+void ComparisonMonitor::update_settings(const json &settings)
+{
+    const std::string dcs_id_compare_monitor_raw = EPLJSONUtils::GetStringByName(settings, "dcs_id_compare_monitor");
+    const std::string dcs_id_compare_condition_raw =
+        EPLJSONUtils::GetStringByName(settings, "dcs_id_compare_condition");
+    const std::string dcs_id_comparison_value_raw = EPLJSONUtils::GetStringByName(settings, "dcs_id_comparison_value");
+
+    const bool compare_monitor_is_populated = is_integer(dcs_id_compare_monitor_raw);
+    const bool comparison_value_is_populated = is_number(dcs_id_comparison_value_raw);
+    settings_are_filled_ = compare_monitor_is_populated && comparison_value_is_populated;
+
+    if (settings_are_filled_) {
+        dcs_id_compare_monitor_ = std::stoi(dcs_id_compare_monitor_raw);
+        dcs_id_comparison_value_ = Decimal(dcs_id_comparison_value_raw);
+        if (dcs_id_compare_condition_raw == "EQUAL_TO") {
+            dcs_id_compare_condition_ = Comparison::EQUAL_TO;
+        } else if (dcs_id_compare_condition_raw == "LESS_THAN") {
+            dcs_id_compare_condition_ = Comparison::LESS_THAN;
+        } else // Default in Property Inspector html is GREATER_THAN.
+        {
+            dcs_id_compare_condition_ = Comparison::GREATER_THAN;
+        }
+    }
+}
+
+std::optional<int> ComparisonMonitor::determineContextState(DcsInterface &dcs_interface)
+{
+    if (settings_are_filled_) {
+        const auto maybe_current_game_value = dcs_interface.get_decimal_of_dcs_id(dcs_id_compare_monitor_);
+        if (maybe_current_game_value.has_value()) {
+            return comparison_is_satisfied(maybe_current_game_value.value()) ? 1 : 0;
+        }
+    }
+    return std::nullopt;
+}
+
+bool ComparisonMonitor::comparison_is_satisfied(Decimal current_game_value)
+{
+    bool comparison_result = false;
+    switch (dcs_id_compare_condition_) {
+    case Comparison::EQUAL_TO:
+        comparison_result = (current_game_value == dcs_id_comparison_value_);
+        break;
+    case Comparison::LESS_THAN:
+        comparison_result = (current_game_value < dcs_id_comparison_value_);
+        break;
+    case Comparison::GREATER_THAN:
+        comparison_result = (current_game_value > dcs_id_comparison_value_);
+        break;
+    }
+    return comparison_result;
+}

--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
@@ -26,7 +26,7 @@ class ComparisonMonitor
      * @param dcs_interface Interface to request current game state from.
      * @return The Streamdeck context should be set to if all settings are filled.
      */
-    std::optional<int> determineContextState(DcsInterface &dcs_interface);
+    int determineContextState(DcsInterface &dcs_interface);
 
   private:
     enum class Comparison { GREATER_THAN, EQUAL_TO, LESS_THAN };

--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
@@ -26,7 +26,7 @@ class ComparisonMonitor
      * @param dcs_interface Interface to request current game state from.
      * @return The Streamdeck context should be set to if all settings are filled.
      */
-    int determineContextState(DcsInterface &dcs_interface);
+    int determineContextState(DcsInterface &dcs_interface) const;
 
   private:
     enum class Comparison { GREATER_THAN, EQUAL_TO, LESS_THAN };
@@ -36,7 +36,7 @@ class ComparisonMonitor
      *
      * @param current_game_value
      */
-    bool comparison_is_satisfied(Decimal current_game_value);
+    bool comparison_is_satisfied(Decimal current_game_value) const;
 
     // Status of user-filled fields.
     bool settings_are_filled_ = false; // True if all DCS ID comparison monitor settings have been set.

--- a/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
+++ b/Sources/StreamdeckContext/Monitors/ComparisonMonitor.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Charles Tytler
+
+#pragma once
+
+#include "../../Common/EPLJSONUtils.h"
+#include "../../DcsInterface/DcsInterface.h"
+#include "../../Utilities/Decimal.h"
+
+#include <optional>
+class ComparisonMonitor
+{
+  public:
+    ComparisonMonitor() = default;
+    ComparisonMonitor(const json &settings);
+
+    /**
+     * @brief Updates internal monitor conditions based on user settings.
+     *
+     * @param settings Json settings from Streamdeck property inspector.
+     */
+    void update_settings(const json &settings);
+
+    /**
+     * @brief Determines what the context state should be according to current the current game state.
+     *
+     * @param dcs_interface Interface to request current game state from.
+     * @return The Streamdeck context should be set to if all settings are filled.
+     */
+    std::optional<int> determineContextState(DcsInterface &dcs_interface);
+
+  private:
+    enum class Comparison { GREATER_THAN, EQUAL_TO, LESS_THAN };
+
+    /**
+     * @brief Checks if current game value satisfies the comparison criteria configured in settings.
+     *
+     * @param current_game_value
+     */
+    bool comparison_is_satisfied(Decimal current_game_value);
+
+    // Status of user-filled fields.
+    bool settings_are_filled_ = false; // True if all DCS ID comparison monitor settings have been set.
+
+    // Stored settings extracted from user-filled fields.
+    int dcs_id_compare_monitor_ = 0; // DCS ID to monitor for context state setting according to value comparison.
+    Comparison dcs_id_compare_condition_ = Comparison::GREATER_THAN; // Comparison to use for DCS ID compare monitor.
+    Decimal dcs_id_comparison_value_; // Value to compare DCS ID compare monitor value to.
+};

--- a/Sources/StreamdeckContext/Monitors/IncrementMonitor.cpp
+++ b/Sources/StreamdeckContext/Monitors/IncrementMonitor.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021 Charles Tytler
+
+#include "pch.h"
+
+#include "../../Utilities/StringUtilities.h"
+#include "IncrementMonitor.h"
+
+IncrementMonitor::IncrementMonitor(const json &settings) { update_settings(settings); }
+
+void IncrementMonitor::update_settings(const json &settings)
+{
+    const std::string dcs_id_increment_monitor_raw =
+        EPLJSONUtils::GetStringByName(settings, "dcs_id_increment_monitor");
+
+    // Process status of settings.
+    increment_monitor_is_set_ = is_integer(dcs_id_increment_monitor_raw);
+
+    // Update internal settings of class instance.
+    if (increment_monitor_is_set_) {
+        dcs_id_increment_monitor_ = std::stoi(dcs_id_increment_monitor_raw);
+    }
+}
+
+void IncrementMonitor::update(DcsInterface &dcs_interface)
+{
+    if (increment_monitor_is_set_) {
+        const std::optional<Decimal> maybe_current_game_value =
+            dcs_interface.get_decimal_of_dcs_id(dcs_id_increment_monitor_);
+        if (maybe_current_game_value.has_value()) {
+            current_increment_value_ = maybe_current_game_value.value();
+        }
+    }
+}
+
+Decimal IncrementMonitor::get_increment_after_command(const Decimal &delta_cmd,
+                                                      const Decimal &increment_min,
+                                                      const Decimal &increment_max,
+                                                      const bool cycling_is_allowed)
+{
+    if (increment_monitor_is_set_) {
+        current_increment_value_ += delta_cmd;
+
+        if (current_increment_value_ < increment_min) {
+            current_increment_value_ = cycling_is_allowed ? increment_max : increment_min;
+        } else if (current_increment_value_ > increment_max) {
+            current_increment_value_ = cycling_is_allowed ? increment_min : increment_max;
+        }
+        return current_increment_value_;
+    } else {
+        return Decimal("0");
+    }
+}

--- a/Sources/StreamdeckContext/Monitors/IncrementMonitor.h
+++ b/Sources/StreamdeckContext/Monitors/IncrementMonitor.h
@@ -1,0 +1,54 @@
+// Copyright 2021 Charles Tytler
+
+#pragma once
+
+#include "../../Common/EPLJSONUtils.h"
+#include "../../DcsInterface/DcsInterface.h"
+#include "../../Utilities/Decimal.h"
+
+#include <string>
+
+class IncrementMonitor
+{
+  public:
+    IncrementMonitor() = default;
+    IncrementMonitor(const json &settings);
+
+    /**
+     * @brief Updates internal monitor conditions based on user settings.
+     *
+     * @param settings Json settings from Streamdeck property inspector.
+     */
+    void update_settings(const json &settings);
+
+    /**
+     * @brief Keeps the increment status up to date with game state.
+     *
+     * @param dcs_interface Interface to request current game state from.
+     */
+    void update(DcsInterface &dcs_interface);
+
+    /**
+     * @brief Applies a commanded delta to the internal increment and returns the new current value.
+     *
+     * @param delta_cmd The change from current increment being commanded by user.
+     * @param increment_min The minimum value to clamp the increment to.
+     * @param increment_max The maximum value to clamp the increment to.
+     * @param cycling_is_allowed Flag to indicate that if the min/max is reached, the increment should wrap around to
+     * other end of range.
+     * @return Updated current value of the increment.
+     */
+    Decimal get_increment_after_command(const Decimal &delta_cmd,
+                                        const Decimal &increment_min,
+                                        const Decimal &increment_max,
+                                        const bool cycling_is_allowed);
+
+  private:
+    // Status of user-filled fields.
+    bool increment_monitor_is_set_ = false; // True if a DCS ID increment monitor setting has been set.
+
+    Decimal current_increment_value_; // Stored value for increment button types.
+
+    // Stored settings extracted from user-filled fields.
+    int dcs_id_increment_monitor_ = 0; // DCS ID to monitor for updating current increment value from game state.
+};

--- a/Sources/StreamdeckContext/Monitors/TitleMonitor.cpp
+++ b/Sources/StreamdeckContext/Monitors/TitleMonitor.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021 Charles Tytler
+
+#include "pch.h"
+
+#include "../../Utilities/StringUtilities.h"
+#include "TitleMonitor.h"
+
+TitleMonitor::TitleMonitor(const json &settings) { update_settings(settings); }
+
+void TitleMonitor::update_settings(const json &settings)
+{
+    const std::string dcs_id_string_monitor_raw = EPLJSONUtils::GetStringByName(settings, "dcs_id_string_monitor");
+    // Set boolean from checkbox using default false value if it doesn't exist in "settings".
+    const std::string string_monitor_vertical_spacing_raw =
+        EPLJSONUtils::GetStringByName(settings, "string_monitor_vertical_spacing");
+    string_monitor_passthrough_ = EPLJSONUtils::GetBoolByName(settings, "string_monitor_passthrough_check", true);
+    std::stringstream string_monitor_mapping_raw;
+    string_monitor_mapping_raw << EPLJSONUtils::GetStringByName(settings, "string_monitor_mapping");
+
+    string_monitor_is_set_ = is_integer(dcs_id_string_monitor_raw);
+
+    if (string_monitor_is_set_) {
+        dcs_id_string_monitor_ = std::stoi(dcs_id_string_monitor_raw);
+        if (is_integer(string_monitor_vertical_spacing_raw)) {
+            string_monitor_vertical_spacing_ = std::stoi(string_monitor_vertical_spacing_raw);
+        }
+        if (!string_monitor_passthrough_) {
+            string_monitor_mapping_.clear();
+            std::pair<std::string, std::string> key_and_value;
+            while (pop_key_and_value(string_monitor_mapping_raw, ',', '=', key_and_value)) {
+                string_monitor_mapping_[key_and_value.first] = key_and_value.second;
+            }
+        }
+    }
+}
+
+std::string TitleMonitor::determineTitle(DcsInterface &dcs_interface)
+{
+    std::string updated_title = "";
+
+    if (string_monitor_is_set_) {
+        const std::optional<std::string> maybe_current_game_value =
+            dcs_interface.get_value_of_dcs_id(dcs_id_string_monitor_);
+        if (maybe_current_game_value.has_value()) {
+            updated_title = convertGameStateToTitle(maybe_current_game_value.value());
+        }
+    }
+
+    return updated_title;
+}
+
+std::string TitleMonitor::convertGameStateToTitle(const std::string &current_game_value)
+{
+    std::string title;
+    if (string_monitor_passthrough_) {
+        title = current_game_value;
+    } else {
+        title = string_monitor_mapping_[current_game_value];
+    }
+    // Apply vertical spacing.
+    if (string_monitor_vertical_spacing_ < 0) {
+        for (int i = 0; i > string_monitor_vertical_spacing_; --i) {
+            title = "\n" + title;
+        }
+    } else {
+        for (int i = 0; i < string_monitor_vertical_spacing_; ++i) {
+            title = title + "\n";
+        }
+    }
+    return title;
+}

--- a/Sources/StreamdeckContext/Monitors/TitleMonitor.h
+++ b/Sources/StreamdeckContext/Monitors/TitleMonitor.h
@@ -1,0 +1,46 @@
+// Copyright 2021 Charles Tytler
+
+#pragma once
+
+#include "../../Common/EPLJSONUtils.h"
+#include "../../DcsInterface/DcsInterface.h"
+
+#include <string>
+
+class TitleMonitor
+{
+  public:
+    TitleMonitor() = default;
+    TitleMonitor(const json &settings);
+
+    /**
+     * @brief Updates internal monitor conditions based on user settings.
+     *
+     * @param settings Json settings from Streamdeck property inspector.
+     */
+    void update_settings(const json &settings);
+
+    /**
+     * @brief Determines what the context title text should be according to current the current game state.
+     *
+     * @param dcs_interface Interface to request current game state from.
+     * @return The string that the Title should be set to if all settings are filled.
+     */
+    std::string determineTitle(DcsInterface &dcs_interface);
+
+  private:
+    /**
+     * @brief Converts game string value to a title according to settings.
+     *
+     * @param current_game_value
+     */
+    std::string convertGameStateToTitle(const std::string &current_game_value);
+
+    bool string_monitor_is_set_ = false; // True if all DCS ID string monitor settings have been set.
+
+    int dcs_id_string_monitor_ = 0;           // DCS ID to monitor for context title.
+    int string_monitor_vertical_spacing_ = 0; // Vertical spacing (number of '\n') to include before or after title.
+    bool string_monitor_passthrough_ = true;  // Flag set by user to passthrough string to title unaltered.
+    std::map<std::string, std::string>
+        string_monitor_mapping_; // Map of received values to title text to display on context.
+};

--- a/Sources/StreamdeckContext/StreamDeckContextTypes.h
+++ b/Sources/StreamdeckContext/StreamDeckContextTypes.h
@@ -1,0 +1,5 @@
+// Copyright 2021 Charles Tytler
+
+#pragma once
+
+enum class ContextState { kFirst = 0, kSecond };

--- a/Sources/StreamdeckContext/StreamdeckContext.cpp
+++ b/Sources/StreamdeckContext/StreamdeckContext.cpp
@@ -36,8 +36,8 @@ void StreamdeckContext::updateContextState(DcsInterface &dcs_interface, ESDConne
         }
     }
 
-    if (updated_state.has_value() && (updated_state.value() != current_state_)) {
-        current_state_ = updated_state.value();
+    if (updated_state != current_state_) {
+        current_state_ = updated_state;
         mConnectionManager->SetState(current_state_, context_);
     }
     if (updated_title != current_title_) {

--- a/Sources/StreamdeckContext/StreamdeckContext.cpp
+++ b/Sources/StreamdeckContext/StreamdeckContext.cpp
@@ -15,26 +15,10 @@ StreamdeckContext::StreamdeckContext(const std::string &context, const json &set
 
 void StreamdeckContext::updateContextState(DcsInterface &dcs_interface, ESDConnectionManager *mConnectionManager)
 {
-    // Initialize to default values.
-    std::string updated_title = "";
-
-    if (increment_monitor_is_set_) {
-        const std::optional<Decimal> maybe_current_game_value =
-            dcs_interface.get_decimal_of_dcs_id(dcs_id_increment_monitor_);
-        if (maybe_current_game_value.has_value()) {
-            current_increment_value_ = maybe_current_game_value.value();
-        }
-    }
 
     const auto updated_state = comparison_monitor_.determineContextState(dcs_interface);
-
-    if (string_monitor_is_set_) {
-        const std::optional<std::string> maybe_current_game_value =
-            dcs_interface.get_value_of_dcs_id(dcs_id_string_monitor_);
-        if (maybe_current_game_value.has_value()) {
-            updated_title = determineTitleForStringMonitor(maybe_current_game_value.value());
-        }
-    }
+    const auto updated_title = title_monitor_.determineTitle(dcs_interface);
+    increment_monitor_.update(dcs_interface);
 
     if (updated_state != current_state_) {
         current_state_ = updated_state;
@@ -65,42 +49,9 @@ void StreamdeckContext::forceSendStateAfterDelay(const int delay_count)
 
 void StreamdeckContext::updateContextSettings(const json &settings)
 {
-
     comparison_monitor_.update_settings(settings);
-
-    // Read in settings.
-    const std::string dcs_id_increment_monitor_raw =
-        EPLJSONUtils::GetStringByName(settings, "dcs_id_increment_monitor");
-    const std::string dcs_id_string_monitor_raw = EPLJSONUtils::GetStringByName(settings, "dcs_id_string_monitor");
-    // Set boolean from checkbox using default false value if it doesn't exist in "settings".
-    const std::string string_monitor_vertical_spacing_raw =
-        EPLJSONUtils::GetStringByName(settings, "string_monitor_vertical_spacing");
-    string_monitor_passthrough_ = EPLJSONUtils::GetBoolByName(settings, "string_monitor_passthrough_check", true);
-    std::stringstream string_monitor_mapping_raw;
-    string_monitor_mapping_raw << EPLJSONUtils::GetStringByName(settings, "string_monitor_mapping");
-
-    // Process status of settings.
-    increment_monitor_is_set_ = is_integer(dcs_id_increment_monitor_raw);
-    string_monitor_is_set_ = is_integer(dcs_id_string_monitor_raw);
-
-    // Update internal settings of class instance.
-    if (increment_monitor_is_set_) {
-        dcs_id_increment_monitor_ = std::stoi(dcs_id_increment_monitor_raw);
-    }
-
-    if (string_monitor_is_set_) {
-        dcs_id_string_monitor_ = std::stoi(dcs_id_string_monitor_raw);
-        if (is_integer(string_monitor_vertical_spacing_raw)) {
-            string_monitor_vertical_spacing_ = std::stoi(string_monitor_vertical_spacing_raw);
-        }
-        if (!string_monitor_passthrough_) {
-            string_monitor_mapping_.clear();
-            std::pair<std::string, std::string> key_and_value;
-            while (pop_key_and_value(string_monitor_mapping_raw, ',', '=', key_and_value)) {
-                string_monitor_mapping_[key_and_value.first] = key_and_value.second;
-            }
-        }
-    }
+    title_monitor_.update_settings(settings);
+    increment_monitor_.update_settings(settings);
 }
 
 void StreamdeckContext::handleButtonEvent(DcsInterface &dcs_interface,
@@ -110,10 +61,6 @@ void StreamdeckContext::handleButtonEvent(DcsInterface &dcs_interface,
 {
     const std::string button_id = EPLJSONUtils::GetStringByName(inPayload["settings"], "button_id");
     const std::string device_id = EPLJSONUtils::GetStringByName(inPayload["settings"], "device_id");
-
-    // Set boolean from checkbox using default false value if it doesn't exist in "settings".
-    cycle_increments_is_allowed_ =
-        EPLJSONUtils::GetBoolByName(inPayload["settings"], "increment_cycle_allowed_check", false);
 
     if (is_integer(button_id) && is_integer(device_id)) {
         bool send_command = false;
@@ -133,27 +80,7 @@ void StreamdeckContext::handleButtonEvent(DcsInterface &dcs_interface,
     }
 }
 
-std::string StreamdeckContext::determineTitleForStringMonitor(const std::string &current_game_string_value)
-{
-    std::string title;
-    if (string_monitor_passthrough_) {
-        title = current_game_string_value;
-    } else {
-        title = string_monitor_mapping_[current_game_string_value];
-    }
-    // Apply vertical spacing.
-    if (string_monitor_vertical_spacing_ < 0) {
-        for (int i = 0; i > string_monitor_vertical_spacing_; --i) {
-            title = "\n" + title;
-        }
-    } else {
-        for (int i = 0; i < string_monitor_vertical_spacing_; ++i) {
-            title = title + "\n";
-        }
-    }
-    return title;
-}
-
+// TODO: Change determineSend... functions to return an optional rather than a mutable value argument.
 bool StreamdeckContext::determineSendValueForMomentary(const KeyEvent event, const json &settings, std::string &value)
 {
     if (event == KeyEvent::PRESSED) {
@@ -190,22 +117,17 @@ bool StreamdeckContext::determineSendValueForSwitch(const KeyEvent event,
 bool StreamdeckContext::determineSendValueForIncrement(const KeyEvent event, const json &settings, std::string &value)
 {
     if (event == KeyEvent::PRESSED) {
-        const std::string increment_value_str = EPLJSONUtils::GetStringByName(settings, "increment_value");
+        const std::string increment_cmd_value_str = EPLJSONUtils::GetStringByName(settings, "increment_value");
         const std::string increment_min_str = EPLJSONUtils::GetStringByName(settings, "increment_min");
         const std::string increment_max_str = EPLJSONUtils::GetStringByName(settings, "increment_max");
         const bool cycling_is_allowed = EPLJSONUtils::GetBoolByName(settings, "increment_cycle_allowed_check");
-        if (is_number(increment_value_str) && is_number(increment_min_str) && is_number(increment_max_str)) {
-            Decimal increment_min(increment_min_str);
-            Decimal increment_max(increment_max_str);
 
-            current_increment_value_ += Decimal(increment_value_str);
-
-            if (current_increment_value_ < increment_min) {
-                current_increment_value_ = cycle_increments_is_allowed_ ? increment_max : increment_min;
-            } else if (current_increment_value_ > increment_max) {
-                current_increment_value_ = cycle_increments_is_allowed_ ? increment_min : increment_max;
-            }
-            value = current_increment_value_.str();
+        if (is_number(increment_cmd_value_str) && is_number(increment_min_str) && is_number(increment_max_str)) {
+            const auto current_value = increment_monitor_.get_increment_after_command(Decimal(increment_cmd_value_str),
+                                                                                      Decimal(increment_min_str),
+                                                                                      Decimal(increment_max_str),
+                                                                                      cycling_is_allowed);
+            value = current_value.str();
             return true;
         }
     }

--- a/Sources/StreamdeckContext/StreamdeckContext.h
+++ b/Sources/StreamdeckContext/StreamdeckContext.h
@@ -3,9 +3,10 @@
 #pragma once
 
 #include "../DcsInterface/DcsInterface.h"
-#include "../Utilities/Decimal.h"
 #include "../Utilities/StringUtilities.h"
 #include "Monitors/ComparisonMonitor.h"
+#include "Monitors/IncrementMonitor.h"
+#include "Monitors/TitleMonitor.h"
 
 #ifndef UNIT_TEST
 #include "../Common/ESDConnectionManager.h"
@@ -69,14 +70,6 @@ class StreamdeckContext
 
   private:
     /**
-     * @brief Determines what the context title should be according to current game value and string monitor settings.
-     *
-     * @param current_game_string_value Value receieved from DCS.
-     * @return std::string String that the Streamdeck context title should be set to.
-     */
-    std::string determineTitleForStringMonitor(const std::string &current_game_string_value);
-
-    /**
      * @brief Determines the send value for the type of button for KeyDown and KeyUp events.
      *
      * @param event Either a KeyDown or KeyUp event.
@@ -93,27 +86,15 @@ class StreamdeckContext
 
     // Monitors.
     ComparisonMonitor comparison_monitor_{}; // Monitors DCS ID to determine the image state of Streamdeck context.
-
-    // Status of user-filled fields.
-    bool increment_monitor_is_set_ = false; // True if a DCS ID increment monitor setting has been set.
-    bool string_monitor_is_set_ = false;    // True if all DCS ID string monitor settings have been set.
+    TitleMonitor title_monitor_{};           // Monitors DCS ID to determine the title text of Streamdeck context.
+    IncrementMonitor increment_monitor_{};   // Monitors DCS ID to determine the state of an incremental switch.
 
     // Optional settings.
     std::optional<int> delay_for_force_send_state_; // When populated, requests a force send of state to Streamdeck
                                                     // after counting down the stored delay value.
 
     // Context state.
-    int current_state_ = 0;                    // Stored state of the context.
-    std::string current_title_ = "";           // Stored title of the context.
-    Decimal current_increment_value_;          // Stored value for increment button types.
-    bool cycle_increments_is_allowed_ = false; // Flag set by user settings for increment button types.
-    bool disable_release_value_ = false;       // Flag set by user settings for momentary button types.
-
-    // Stored settings extracted from user-filled fields.
-    int dcs_id_increment_monitor_ = 0;        // DCS ID to monitor for updating current increment value from game state.
-    int dcs_id_string_monitor_ = 0;           // DCS ID to monitor for context title.
-    int string_monitor_vertical_spacing_ = 0; // Vertical spacing (number of '\n') to include before or after title.
-    bool string_monitor_passthrough_ = true;  // Flag set by user to passthrough string to title unaltered.
-    std::map<std::string, std::string>
-        string_monitor_mapping_; // Map of received values to title text to display on context.
+    int current_state_ = 0;              // Stored state of the context.
+    std::string current_title_ = "";     // Stored title of the context.
+    bool disable_release_value_ = false; // Flag set by user settings for momentary button types.
 };

--- a/Sources/Test/ComparisonMonitorTest.cpp
+++ b/Sources/Test/ComparisonMonitorTest.cpp
@@ -1,0 +1,213 @@
+// Copyright 2021 Charles Tytler
+
+#include "gtest/gtest.h"
+
+#include "../StreamdeckContext/Monitors/ComparisonMonitor.cpp"
+
+namespace test
+{
+
+/* COMMENTED OUT - ENABLE BEFORE LANDING
+
+class ComparisonTestFixture : public ::testing::Test
+{
+  public:
+    ComparisonTestFixture()
+        : // Create StreamdeckContexts with different comparison selections to test.
+          monitor_with_equals({{"dcs_id_compare_monitor", "123"},
+                               {"dcs_id_compare_condition", "EQUAL_TO"},
+                               {"dcs_id_comparison_value", std::to_string(comparison_value)}}),
+          monitor_with_less_than({{"dcs_id_compare_monitor", "123"},
+                                  {"dcs_id_compare_condition", "LESS_THAN"},
+                                  {"dcs_id_comparison_value", std::to_string(comparison_value)}}),
+          monitor_with_greater_than({{"dcs_id_compare_monitor", "123"},
+                                     {"dcs_id_compare_condition", "GREATER_THAN"},
+                                     {"dcs_id_comparison_value", std::to_string(comparison_value)}})
+    {
+    }
+
+    const float comparison_value = 1.56F;
+    ComparisonMonitor monitor_with_equals;
+    ComparisonMonitor monitor_with_less_than;
+    ComparisonMonitor monitor_with_greater_than;
+};
+
+
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_zero)
+{
+    // Test -- Compare 0 to non-zero comparison_value.
+    const std::string mock_dcs_message = "header*123=0";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+
+    ComparisonMonitor::ContextState state;
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_equals.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_less_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "ctx_less_than");
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+}
+
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_lesser_value)
+{
+    // Test -- Compare value less than comparison_value.
+    const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value / 2.0F);
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_equals.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_less_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "ctx_less_than");
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+}
+
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_equal_value)
+{
+    // Test -- Compare value equal to comparison_value.
+    const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value);
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_equals.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "ctx_equals");
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_less_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+}
+
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_greater_value)
+{
+    // Test -- Compare value greater than comparison_value.
+    const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value * 2.0F);
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_equals.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_less_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "");
+    esd_connection_manager.clear_buffer();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.context_, "ctx_greater_than");
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+}
+
+// Test comparison to invalid values.
+
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_integer)
+{
+    // Send game state value as an integer -- should still resolve to float comparison.
+    const std::string mock_dcs_message = "header*123=20";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_alphanumeric)
+{
+    // Send game state value with letters -- should treat as string and not try comparison.
+    const std::string mock_dcs_message = "header*123=20a";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_empty)
+{
+    // Send game state as empty -- should treat as string and not try comparison.
+    const std::string mock_dcs_message = "header*123=";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_string_of_spaces)
+{
+    // Send game state value as string of spaces -- should treat as (non-numeric) string and not try comparison.
+    const std::string mock_dcs_message = "header*123=    ";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_dcs_id_float)
+{
+    // Send DCS ID as a float -- should not read update.
+    const std::string mock_dcs_message = "header*123.0=2.0";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_with_settings_id_as_float)
+{
+    // Send valid game state, but make settings dcs_id monitor value invalid as a float.
+    json settings;
+    settings["dcs_id_compare_monitor"] = "123.0";
+    state = monitor_with_greater_than.updateContextSettings(settings);
+    const std::string mock_dcs_message = "header*123=2.0";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_with_invalid_settings_comparison_value)
+{
+    // Send valid game state, but make settings comparison value invalid as a float.
+    json settings;
+    settings["dcs_id_compare_monitor"] = "123";
+    settings["dcs_id_comparison_value"] = "1.0abc";
+    state = monitor_with_greater_than.updateContextSettings(settings);
+    const std::string mock_dcs_message = "header*123=2.0";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 0);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_float_with_leading_spaces)
+{
+    // Use leading spaces, zeros, and integers -- should be compared as floats without problem.
+    json settings;
+    settings["dcs_id_compare_monitor"] = "  00123";
+    settings["dcs_id_comparison_value"] = "  0001.00";
+    state = monitor_with_greater_than.updateContextSettings(settings);
+    const std::string mock_dcs_message = "header*123=   002";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+}
+TEST_F(ComparisonTestFixture, dcs_id_float_compare_to_float_with_trailing_space)
+{
+    json settings;
+    settings["dcs_id_compare_monitor"] = "123";
+    settings["dcs_id_comparison_value"] = "1.0 "; //< Trailing space
+    state = monitor_with_greater_than.updateContextSettings(settings);
+    const std::string mock_dcs_message = "header*123=2.0";
+    mock_dcs.send(mock_dcs_message);
+    dcs_interface.update_dcs_state();
+    state = monitor_with_greater_than.determineContextState(&dcs_interface);
+    EXPECT_EQ(esd_connection_manager.state_, 1);
+}
+*/
+
+} // namespace test

--- a/Sources/Test/IncrementMonitorTest.cpp
+++ b/Sources/Test/IncrementMonitorTest.cpp
@@ -1,0 +1,231 @@
+// Copyright 2021 Charles Tytler
+
+#include "gtest/gtest.h"
+
+#include "../StreamdeckContext/Monitors/IncrementMonitor.cpp"
+
+namespace test
+{
+
+TEST(IncrementMonitorTest, DefaultConstructor)
+{
+    IncrementMonitor monitor{};
+    EXPECT_EQ(Decimal("0"), monitor.get_increment_after_command(Decimal("99"), Decimal("99"), Decimal("99"), false));
+}
+
+TEST(IncrementMonitorTest, DefaultValueOfZeroWhileIdNotSet)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", ""}}};
+    EXPECT_EQ(Decimal("0"), monitor.get_increment_after_command(Decimal("99"), Decimal("99"), Decimal("99"), false));
+}
+
+TEST(IncrementMonitorTest, IncrementFromZeroByDefault)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", "123"}}};
+    const Decimal delta{"0.1"};
+    const Decimal min{"0"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("0.1"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST(IncrementMonitorTest, IncrementFromBelowRange)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", "123"}}};
+    const Decimal delta{"1"};
+    const Decimal min{"10"};
+    const Decimal max{"20"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("10"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST(IncrementMonitorTest, IncrementFromAboveRange)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", "123"}}};
+    const Decimal delta{"1"};
+    const Decimal min{"-20"};
+    const Decimal max{"-10"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("-10"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+class IncrementMonitorTestFixture : public ::testing::Test
+{
+  public:
+    IncrementMonitorTestFixture()
+        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
+          dcs_interface(connection_settings)
+    {
+        // Consume intial reset command sent to to mock_dcs.
+        (void)mock_dcs.receive();
+    }
+
+    void set_current_dcs_id_value(const std::string value)
+    {
+        mock_dcs.send("header*" + monitor_id_value + "=" + value);
+        dcs_interface.update_dcs_state();
+    }
+
+    std::string monitor_id_value = "123";
+    DcsConnectionSettings connection_settings{"1908", "1909", "127.0.0.1"};
+    UdpSocket mock_dcs;         // A socket that will mock Send/Receive messages from DCS.
+    DcsInterface dcs_interface; // DCS Interface to test.
+};
+
+TEST_F(IncrementMonitorTestFixture, CurrentValueIsUpdatedFromDcsInterface)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0.5");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0"};
+    const Decimal min{"0"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("0.5"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, CurrentValueUpdateIsClampedToRange)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0.5");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0"};
+    const Decimal min{"10"};
+    const Decimal max{"20"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("10"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementAfterExternalChange)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("-0.5");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0.1"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("-0.4"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementMultipleTimes)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0.1"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    const Decimal expected{"0.5"};
+    Decimal actual;
+    for (int i = 0; i < 5; i++) {
+        actual = monitor.get_increment_after_command(delta, min, max, cycling_is_allowed);
+    }
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementMultipleTimesNegative)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0");
+    monitor.update(dcs_interface);
+    const Decimal delta{"-0.1"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    const Decimal expected{"-0.5"};
+    Decimal actual;
+    for (int i = 0; i < 5; i++) {
+        actual = monitor.get_increment_after_command(delta, min, max, cycling_is_allowed);
+    }
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementToMax)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0.1"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementBeyondMaxCyclingOff)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0.2"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementBeyondMaxCyclingOn)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"0.2"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = true;
+
+    EXPECT_EQ(Decimal("-1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementToMin)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("-0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"-0.1"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("-1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementBeyondMinCyclingOff)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("-0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"-0.2"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = false;
+
+    EXPECT_EQ(Decimal("-1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+TEST_F(IncrementMonitorTestFixture, IncrementBeyondMinCyclingOn)
+{
+    IncrementMonitor monitor{{{"dcs_id_increment_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("-0.9");
+    monitor.update(dcs_interface);
+    const Decimal delta{"-0.2"};
+    const Decimal min{"-1"};
+    const Decimal max{"1"};
+    const bool cycling_is_allowed = true;
+
+    EXPECT_EQ(Decimal("1.0"), monitor.get_increment_after_command(delta, min, max, cycling_is_allowed));
+}
+
+} // namespace test

--- a/Sources/Test/StreamdeckContextTest.cpp
+++ b/Sources/Test/StreamdeckContextTest.cpp
@@ -190,71 +190,19 @@ TEST_F(StreamdeckContextTestFixture, update_context_settings)
     EXPECT_EQ(esd_connection_manager.title_, "");
 }
 
-class StreamdeckContextComparisonTestFixture : public StreamdeckContextTestFixture
+TEST_F(StreamdeckContextTestFixture, ComparisonMonitorSetsState)
 {
-  public:
-    StreamdeckContextComparisonTestFixture()
-        : // Create StreamdeckContexts with different comparison selections to test.
-          context_with_equals("ctx_equals",
-                              {{"dcs_id_compare_monitor", "123"},
-                               {"dcs_id_compare_condition", "EQUAL_TO"},
-                               {"dcs_id_comparison_value", std::to_string(comparison_value)}}),
-          context_with_less_than("ctx_less_than",
-                                 {{"dcs_id_compare_monitor", "123"},
-                                  {"dcs_id_compare_condition", "LESS_THAN"},
-                                  {"dcs_id_comparison_value", std::to_string(comparison_value)}}),
-          context_with_greater_than("ctx_greater_than",
-                                    {{"dcs_id_compare_monitor", "123"},
-                                     {"dcs_id_compare_condition", "GREATER_THAN"},
-                                     {"dcs_id_comparison_value", std::to_string(comparison_value)}})
-    {
-    }
-
-    const float comparison_value = 1.56F;
-    StreamdeckContext context_with_equals;
-    StreamdeckContext context_with_less_than;
-    StreamdeckContext context_with_greater_than;
-};
-
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_zero)
-{
-    // Test -- Compare 0 to non-zero comparison_value.
-    const std::string mock_dcs_message = "header*123=0";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
+    constexpr int comparison_value = 10;
+    StreamdeckContext context_with_equals{"ctx_equals",
+                                          {{"dcs_id_compare_monitor", "123"},
+                                           {"dcs_id_compare_condition", "EQUAL_TO"},
+                                           {"dcs_id_comparison_value", std::to_string(comparison_value)}}};
 
     esd_connection_manager.clear_buffer();
     context_with_equals.updateContextState(dcs_interface, &esd_connection_manager);
     EXPECT_EQ(esd_connection_manager.context_, "");
-    esd_connection_manager.clear_buffer();
-    context_with_less_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "ctx_less_than");
-    EXPECT_EQ(esd_connection_manager.state_, 1);
-    esd_connection_manager.clear_buffer();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-}
+    EXPECT_EQ(esd_connection_manager.state_, 0);
 
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_lesser_value)
-{
-    // Test -- Compare value less than comparison_value.
-    const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value / 2.0F);
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-
-    esd_connection_manager.clear_buffer();
-    context_with_equals.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-    esd_connection_manager.clear_buffer();
-    context_with_less_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "ctx_less_than");
-    esd_connection_manager.clear_buffer();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-}
-
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_equal_value)
-{
     // Test -- Compare value equal to comparison_value.
     const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value);
     mock_dcs.send(mock_dcs_message);
@@ -263,131 +211,6 @@ TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_equal_val
     esd_connection_manager.clear_buffer();
     context_with_equals.updateContextState(dcs_interface, &esd_connection_manager);
     EXPECT_EQ(esd_connection_manager.context_, "ctx_equals");
-    EXPECT_EQ(esd_connection_manager.state_, 1);
-    esd_connection_manager.clear_buffer();
-    context_with_less_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-    esd_connection_manager.clear_buffer();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-}
-
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_greater_value)
-{
-    // Test -- Compare value greater than comparison_value.
-    const std::string mock_dcs_message = "header*123=" + std::to_string(comparison_value * 2.0F);
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-
-    esd_connection_manager.clear_buffer();
-    context_with_equals.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-    esd_connection_manager.clear_buffer();
-    context_with_less_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "");
-    esd_connection_manager.clear_buffer();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.context_, "ctx_greater_than");
-    EXPECT_EQ(esd_connection_manager.state_, 1);
-}
-
-// Test comparison to invalid values.
-
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_integer)
-{
-    // Send game state value as an integer -- should still resolve to float comparison.
-    const std::string mock_dcs_message = "header*123=20";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 1);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_alphanumeric)
-{
-    // Send game state value with letters -- should treat as string and not try comparison.
-    const std::string mock_dcs_message = "header*123=20a";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_empty)
-{
-    // Send game state as empty -- should treat as string and not try comparison.
-    const std::string mock_dcs_message = "header*123=";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_string_of_spaces)
-{
-    // Send game state value as string of spaces -- should treat as (non-numeric) string and not try comparison.
-    const std::string mock_dcs_message = "header*123=    ";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_dcs_id_float)
-{
-    // Send DCS ID as a float -- should not read update.
-    const std::string mock_dcs_message = "header*123.0=2.0";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_with_settings_id_as_float)
-{
-    // Send valid game state, but make settings dcs_id monitor value invalid as a float.
-    json settings;
-    settings["dcs_id_compare_monitor"] = "123.0";
-    context_with_greater_than.updateContextSettings(settings);
-    const std::string mock_dcs_message = "header*123=2.0";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_with_invalid_settings_comparison_value)
-{
-    // Send valid game state, but make settings comparison value invalid as a float.
-    json settings;
-    settings["dcs_id_compare_monitor"] = "123";
-    settings["dcs_id_comparison_value"] = "1.0abc";
-    context_with_greater_than.updateContextSettings(settings);
-    const std::string mock_dcs_message = "header*123=2.0";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 0);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_float_with_leading_spaces)
-{
-    // Use leading spaces, zeros, and integers -- should be compared as floats without problem.
-    json settings;
-    settings["dcs_id_compare_monitor"] = "  00123";
-    settings["dcs_id_comparison_value"] = "  0001.00";
-    context_with_greater_than.updateContextSettings(settings);
-    const std::string mock_dcs_message = "header*123=   002";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
-    EXPECT_EQ(esd_connection_manager.state_, 1);
-}
-TEST_F(StreamdeckContextComparisonTestFixture, dcs_id_float_compare_to_float_with_trailing_space)
-{
-    json settings;
-    settings["dcs_id_compare_monitor"] = "123";
-    settings["dcs_id_comparison_value"] = "1.0 "; //< Trailing space
-    context_with_greater_than.updateContextSettings(settings);
-    const std::string mock_dcs_message = "header*123=2.0";
-    mock_dcs.send(mock_dcs_message);
-    dcs_interface.update_dcs_state();
-    context_with_greater_than.updateContextState(dcs_interface, &esd_connection_manager);
     EXPECT_EQ(esd_connection_manager.state_, 1);
 }
 

--- a/Sources/Test/Test.vcxproj
+++ b/Sources/Test/Test.vcxproj
@@ -33,6 +33,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="ComparisonMonitorTest.cpp" />
     <ClCompile Include="DcsIdLookupTest.cpp" />
     <ClCompile Include="DcsInterfaceTest.cpp" />
     <ClCompile Include="UdpSocketTest.cpp" />

--- a/Sources/Test/Test.vcxproj
+++ b/Sources/Test/Test.vcxproj
@@ -36,6 +36,8 @@
     <ClCompile Include="ComparisonMonitorTest.cpp" />
     <ClCompile Include="DcsIdLookupTest.cpp" />
     <ClCompile Include="DcsInterfaceTest.cpp" />
+    <ClCompile Include="IncrementMonitorTest.cpp" />
+    <ClCompile Include="TitleMonitorTest.cpp" />
     <ClCompile Include="UdpSocketTest.cpp" />
     <ClCompile Include="DecimalTest.cpp" />
     <ClCompile Include="StringUtilitiesTest.cpp" />

--- a/Sources/Test/TitleMonitorTest.cpp
+++ b/Sources/Test/TitleMonitorTest.cpp
@@ -1,0 +1,113 @@
+// Copyright 2021 Charles Tytler
+
+#include "gtest/gtest.h"
+
+#include "../StreamdeckContext/Monitors/TitleMonitor.cpp"
+
+namespace test
+{
+
+class TitleMonitorTestFixture : public ::testing::Test
+{
+  public:
+    TitleMonitorTestFixture()
+        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
+          dcs_interface(connection_settings)
+    {
+        // Consume intial reset command sent to to mock_dcs.
+        (void)mock_dcs.receive();
+    }
+
+    void set_current_dcs_id_value(const std::string value)
+    {
+        mock_dcs.send("header*" + monitor_id_value + "=" + value);
+        dcs_interface.update_dcs_state();
+    }
+
+    std::string monitor_id_value = "123";
+    DcsConnectionSettings connection_settings{"1908", "1909", "127.0.0.1"};
+    UdpSocket mock_dcs;         // A socket that will mock Send/Receive messages from DCS.
+    DcsInterface dcs_interface; // DCS Interface to test.
+};
+
+TEST_F(TitleMonitorTestFixture, TitleUsesStringPassthrough)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value}, {"string_monitor_passthrough_check", true}}};
+    set_current_dcs_id_value("TEXT_STR");
+    EXPECT_EQ("TEXT_STR", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, TitleUsesStringPassthroughDefaultsToTrue)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value}}};
+    set_current_dcs_id_value("TEXT_STR");
+    EXPECT_EQ("TEXT_STR", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, UpdateVerticalSpacingPositive)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value},
+                          {"string_monitor_vertical_spacing", "2"},
+                          {"string_monitor_passthrough_check", true}}};
+    set_current_dcs_id_value("TEXT_STR");
+    EXPECT_EQ("TEXT_STR\n\n", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, UpdateVerticalSpacingNegative)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value},
+                          {"string_monitor_vertical_spacing", "-4"},
+                          {"string_monitor_passthrough_check", true}}};
+    set_current_dcs_id_value("TEXT_STR");
+    EXPECT_EQ("\n\n\n\nTEXT_STR", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, StringMonitorMapping)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value},
+                          {"string_monitor_vertical_spacing", "0"},
+                          {"string_monitor_mapping", "0.0=A,0.1=B,0.2=C"},
+                          {"string_monitor_passthrough_check", false}}};
+    set_current_dcs_id_value("0.0");
+    EXPECT_EQ("A", monitor.determineTitle(dcs_interface));
+    set_current_dcs_id_value("0.1");
+    EXPECT_EQ("B", monitor.determineTitle(dcs_interface));
+    set_current_dcs_id_value("0.2");
+    EXPECT_EQ("C", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, StringMonitorMappingUnknownKey)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", monitor_id_value},
+                          {"string_monitor_vertical_spacing", "0"},
+                          {"string_monitor_mapping", "0.0=A,0.1=B,0.2=C"},
+                          {"string_monitor_passthrough_check", false}}};
+    set_current_dcs_id_value("0.3");
+    EXPECT_EQ("", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, SettingsWithEmptyString)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", ""},
+                          {"string_monitor_vertical_spacing", ""},
+                          {"string_monitor_mapping", ""},
+                          {"string_monitor_passthrough_check", false}}};
+    set_current_dcs_id_value("TEXT_STR");
+    // Returns a default empty string if settings not set.
+    EXPECT_EQ("", monitor.determineTitle(dcs_interface));
+}
+
+TEST_F(TitleMonitorTestFixture, UpdateSettings)
+{
+    TitleMonitor monitor{{{"dcs_id_string_monitor", ""}}};
+    set_current_dcs_id_value("TEXT_STR");
+    EXPECT_EQ("", monitor.determineTitle(dcs_interface));
+
+    monitor.update_settings({{"dcs_id_string_monitor", monitor_id_value},
+                             {"string_monitor_vertical_spacing", "0"},
+                             {"string_monitor_mapping", ""},
+                             {"string_monitor_passthrough_check", true}});
+    EXPECT_EQ("TEXT_STR", monitor.determineTitle(dcs_interface));
+}
+
+} // namespace test

--- a/Sources/Windows/com.ctytler.dcs.sdPlugin.vcxproj
+++ b/Sources/Windows/com.ctytler.dcs.sdPlugin.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="..\DcsInterface\DcsIdLookup.h" />
     <ClInclude Include="..\DcsInterface\DcsInterface.h" />
     <ClInclude Include="..\DcsInterface\DcsInterfaceParameters.h" />
+    <ClInclude Include="..\StreamdeckContext\Monitors\ComparisonMonitor.h" />
     <ClInclude Include="..\StreamdeckContext\StreamdeckContext.h" />
     <ClInclude Include="..\Utilities\Decimal.h" />
     <ClInclude Include="..\Utilities\StringUtilities.h" />
@@ -223,6 +224,7 @@
     </ClCompile>
     <ClCompile Include="..\DcsInterface\DcsIdLookup.cpp" />
     <ClCompile Include="..\DcsInterface\DcsInterface.cpp" />
+    <ClCompile Include="..\StreamdeckContext\Monitors\ComparisonMonitor.cpp" />
     <ClCompile Include="..\StreamdeckContext\StreamdeckContext.cpp" />
     <ClCompile Include="..\Utilities\Decimal.cpp" />
     <ClCompile Include="..\Utilities\StringUtilities.cpp" />

--- a/Sources/Windows/com.ctytler.dcs.sdPlugin.vcxproj
+++ b/Sources/Windows/com.ctytler.dcs.sdPlugin.vcxproj
@@ -190,6 +190,8 @@
     <ClInclude Include="..\DcsInterface\DcsInterface.h" />
     <ClInclude Include="..\DcsInterface\DcsInterfaceParameters.h" />
     <ClInclude Include="..\StreamdeckContext\Monitors\ComparisonMonitor.h" />
+    <ClInclude Include="..\StreamdeckContext\Monitors\IncrementMonitor.h" />
+    <ClInclude Include="..\StreamdeckContext\Monitors\TitleMonitor.h" />
     <ClInclude Include="..\StreamdeckContext\StreamdeckContext.h" />
     <ClInclude Include="..\Utilities\Decimal.h" />
     <ClInclude Include="..\Utilities\StringUtilities.h" />
@@ -225,6 +227,8 @@
     <ClCompile Include="..\DcsInterface\DcsIdLookup.cpp" />
     <ClCompile Include="..\DcsInterface\DcsInterface.cpp" />
     <ClCompile Include="..\StreamdeckContext\Monitors\ComparisonMonitor.cpp" />
+    <ClCompile Include="..\StreamdeckContext\Monitors\IncrementMonitor.cpp" />
+    <ClCompile Include="..\StreamdeckContext\Monitors\TitleMonitor.cpp" />
     <ClCompile Include="..\StreamdeckContext\StreamdeckContext.cpp" />
     <ClCompile Include="..\Utilities\Decimal.cpp" />
     <ClCompile Include="..\Utilities\StringUtilities.cpp" />


### PR DESCRIPTION
Separates out the functionality for monitoring the DCS ID for comparison to set state into its own class.