### PR TITLE
Access SimulatorInterface via unique_ptr for all users

### DIFF
--- a/Sources/SimulatorInterface/Backends/test/DcsExportScriptInterfaceTest.cpp
+++ b/Sources/SimulatorInterface/Backends/test/DcsExportScriptInterfaceTest.cpp
@@ -43,7 +43,7 @@ class DcsExportScriptInterfaceTestFixture : public ::testing::Test
 TEST_F(DcsExportScriptInterfaceTestFixture, empty_game_state_on_initialization)
 {
     // Test that current game state initializes as empty.
-    std::map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
+    std::unordered_map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
     EXPECT_EQ(0, current_game_state.size());
 }
 
@@ -96,7 +96,7 @@ TEST_F(DcsExportScriptInterfaceTestFixture, update_simulator_state_end_of_missio
     std::string mock_dcs_message = "header*761=1:765=2.00:2026=TEXT_STR:2027=4";
     mock_dcs.send(mock_dcs_message);
     simulator_interface.update_simulator_state();
-    std::map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
+    std::unordered_map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
     EXPECT_TRUE(current_game_state.size() > 0);
 
     // Test that game state is cleared when a "STOP" message is received, signifying end of mission.
@@ -217,7 +217,7 @@ TEST_F(DcsExportScriptInterfaceTestFixture, clear_game_state)
     std::string mock_dcs_message = "header*761=1:765=2.00:2026=TEXT_STR:2027=4";
     mock_dcs.send(mock_dcs_message);
     simulator_interface.update_simulator_state();
-    std::map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
+    std::unordered_map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
     EXPECT_TRUE(current_game_state.size() > 0);
 
     // Test that game state is able to be cleared.
@@ -233,7 +233,7 @@ TEST_F(DcsExportScriptInterfaceTestFixture, debug_print_format)
     std::string mock_dcs_message = "header*761=1:765=2.00:2026=TEXT_STR:2027=4";
     mock_dcs.send(mock_dcs_message);
     simulator_interface.update_simulator_state();
-    std::map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
+    std::unordered_map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
 
     EXPECT_EQ(current_game_state[761], "1");
     EXPECT_EQ(current_game_state[765], "2.00");

--- a/Sources/SimulatorInterface/SimulatorInterface.cpp
+++ b/Sources/SimulatorInterface/SimulatorInterface.cpp
@@ -10,30 +10,30 @@ SimulatorInterface::SimulatorInterface(const SimulatorConnectionSettings &settin
 {
 }
 
-bool SimulatorInterface::connection_settings_match(const SimulatorConnectionSettings &settings)
+bool SimulatorInterface::connection_settings_match(const SimulatorConnectionSettings &settings) const
 {
     return ((settings.rx_port == connection_settings_.rx_port) && (settings.tx_port == connection_settings_.tx_port) &&
             (settings.ip_address == connection_settings_.ip_address) &&
             (settings.multicast_address == connection_settings_.multicast_address));
 }
 
-std::string SimulatorInterface::get_current_simulator_module() { return current_game_module_; }
+std::string SimulatorInterface::get_current_simulator_module() const { return current_game_module_; }
 
-std::optional<std::string> SimulatorInterface::get_value_of_simulator_object_state(const int object_id)
+std::optional<std::string> SimulatorInterface::get_value_of_simulator_object_state(const int object_id) const
 {
     if (current_game_state_.count(object_id) > 0) {
-        if (!current_game_state_[object_id].empty()) {
-            return current_game_state_[object_id];
+        if (!current_game_state_.at(object_id).empty()) {
+            return current_game_state_.at(object_id);
         }
     }
     return std::nullopt;
 }
 
-std::optional<Decimal> SimulatorInterface::get_decimal_of_simulator_object_state(const int object_id)
+std::optional<Decimal> SimulatorInterface::get_decimal_of_simulator_object_state(const int object_id) const
 {
     if (current_game_state_.count(object_id) > 0) {
-        if (is_number(current_game_state_[object_id])) {
-            return current_game_state_[object_id];
+        if (is_number(current_game_state_.at(object_id))) {
+            return current_game_state_.at(object_id);
         }
     }
     return std::nullopt;
@@ -41,4 +41,7 @@ std::optional<Decimal> SimulatorInterface::get_decimal_of_simulator_object_state
 
 void SimulatorInterface::clear_game_state() { current_game_state_.clear(); }
 
-std::map<int, std::string> SimulatorInterface::debug_get_current_game_state() { return current_game_state_; }
+std::unordered_map<int, std::string> SimulatorInterface::debug_get_current_game_state() const
+{
+    return current_game_state_;
+}

--- a/Sources/SimulatorInterface/SimulatorInterface.h
+++ b/Sources/SimulatorInterface/SimulatorInterface.h
@@ -5,9 +5,9 @@
 #include "Utilities/Decimal.h"
 #include "Utilities/UdpSocket.h"
 
-#include <map>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using SimulatorConnectionSettings = struct {
@@ -28,7 +28,7 @@ class SimulatorInterface
      * @param settings Connection settings used for simulator socket.
      * @return True if provided connection settings match internal settings.
      */
-    bool connection_settings_match(const SimulatorConnectionSettings &settings);
+    bool connection_settings_match(const SimulatorConnectionSettings &settings) const;
 
     /**
      * @brief Receives simulator state broadcasts, updating internal current game state.
@@ -56,21 +56,21 @@ class SimulatorInterface
      *
      * @return Aircraft module name.
      */
-    std::string get_current_simulator_module();
+    std::string get_current_simulator_module() const;
 
     /**
      * @brief Get the value of object from current game state.
      *
      * @return Optional value of object ID is returned if a value has been logged.
      */
-    std::optional<std::string> get_value_of_simulator_object_state(const int object_id);
+    std::optional<std::string> get_value_of_simulator_object_state(const int object_id) const;
 
     /**
      * @brief Get the value as Decimal of object from current game state.
      *
      * @return Optional value of object is returned if a value has been logged that is a Decimal.
      */
-    std::optional<Decimal> get_decimal_of_simulator_object_state(const int object_id);
+    std::optional<Decimal> get_decimal_of_simulator_object_state(const int object_id) const;
 
     /**
      * @brief Clears history of logged current game state values.
@@ -83,12 +83,12 @@ class SimulatorInterface
      *
      * @return Map of object IDs and their values in current game state.
      */
-    std::map<int, std::string> debug_get_current_game_state();
+    std::unordered_map<int, std::string> debug_get_current_game_state() const;
 
   protected:
     UdpSocket simulator_socket_;      // UDP Socket connection for communicating with simulator.
     std::string current_game_module_; // Stores the current module name being used in game.
-    std::map<int, std::string>
+    std::unordered_map<int, std::string>
         current_game_state_; // Maps object ID keys of received values to their most recently published values.
 
   private:

--- a/Sources/SimulatorInterface/SimulatorInterfaceFactory.cpp
+++ b/Sources/SimulatorInterface/SimulatorInterfaceFactory.cpp
@@ -1,0 +1,15 @@
+// Copyright 2021 Charles Tytler
+
+#include "SimulatorInterfaceFactory.h"
+
+#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+
+std::unique_ptr<SimulatorInterface> SimulatorInterfaceFactory(const SimulatorConnectionSettings &settings,
+                                                              const std::string &backend)
+{
+    if (backend == "DCS-ExportScript") {
+        return std::make_unique<DcsExportScriptInterface>(settings);
+    } else {
+        return std::unique_ptr<SimulatorInterface>{};
+    }
+}

--- a/Sources/SimulatorInterface/SimulatorInterfaceFactory.h
+++ b/Sources/SimulatorInterface/SimulatorInterfaceFactory.h
@@ -1,0 +1,15 @@
+// Copyright 2021 Charles Tytler
+
+#pragma once
+
+#include "SimulatorInterface/SimulatorInterface.h"
+
+#include <memory>
+
+/**
+ * @brief Factory method that generates a SimulatorInterface according to desired backend.
+ *
+ * @param backend The backend to use for communicating with Simulator.
+ */
+std::unique_ptr<SimulatorInterface> SimulatorInterfaceFactory(const SimulatorConnectionSettings &settings,
+                                                              const std::string &backend);

--- a/Sources/SimulatorInterface/test/BaseSimulatorInterfaceTest.cpp
+++ b/Sources/SimulatorInterface/test/BaseSimulatorInterfaceTest.cpp
@@ -40,7 +40,7 @@ TEST(SimulatorInterfaceTest, empty_game_state_on_initialization)
 {
     SimulatorInterface simulator_interface(SimulatorConnectionSettings{"1908", "1909", "127.0.0.1", ""});
     // Test that current game state initializes as empty.
-    std::map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
+    std::unordered_map<int, std::string> current_game_state = simulator_interface.debug_get_current_game_state();
     EXPECT_EQ(0, current_game_state.size());
 }
 

--- a/Sources/SimulatorInterface/test/SimulatorInterfaceFactoryTest.cpp
+++ b/Sources/SimulatorInterface/test/SimulatorInterfaceFactoryTest.cpp
@@ -1,0 +1,24 @@
+// Copyright 2021 Charles Tytler
+
+#include "gtest/gtest.h"
+
+#include "SimulatorInterface/SimulatorInterfaceFactory.h"
+
+namespace test
+{
+
+TEST(SimulatorInterfaceFactoryTest, UnknownBackend)
+{
+    const SimulatorConnectionSettings connection_settings = {"1908", "1909", "127.0.0.1", ""};
+    auto ptr = SimulatorInterfaceFactory(connection_settings, "unknown_backend");
+    EXPECT_FALSE(ptr);
+}
+
+TEST(SimulatorInterfaceFactoryTest, DcsExportScriptBackend)
+{
+    const SimulatorConnectionSettings connection_settings = {"1908", "1909", "127.0.0.1", ""};
+    auto ptr = SimulatorInterfaceFactory(connection_settings, "DCS-ExportScript");
+    EXPECT_TRUE(ptr);
+}
+
+} // namespace test

--- a/Sources/StreamdeckContext/ExportMonitors/ImageStateMonitor.cpp
+++ b/Sources/StreamdeckContext/ExportMonitors/ImageStateMonitor.cpp
@@ -31,11 +31,11 @@ void ImageStateMonitor::update_settings(const json &settings)
     }
 }
 
-int ImageStateMonitor::determineContextState(SimulatorInterface &simulator_interface) const
+int ImageStateMonitor::determineContextState(const std::unique_ptr<SimulatorInterface> &simulator_interface) const
 {
     if (settings_are_filled_) {
         const auto maybe_current_game_value =
-            simulator_interface.get_decimal_of_simulator_object_state(dcs_id_compare_monitor_);
+            simulator_interface->get_decimal_of_simulator_object_state(dcs_id_compare_monitor_);
         if (maybe_current_game_value.has_value()) {
             return comparison_is_satisfied(maybe_current_game_value.value()) ? 1 : 0;
         }

--- a/Sources/StreamdeckContext/ExportMonitors/ImageStateMonitor.h
+++ b/Sources/StreamdeckContext/ExportMonitors/ImageStateMonitor.h
@@ -26,7 +26,7 @@ class ImageStateMonitor
      * @param simulator_interface Interface to request current game state from.
      * @return The Streamdeck context should be set to if all settings are filled.
      */
-    int determineContextState(SimulatorInterface &simulator_interface) const;
+    int determineContextState(const std::unique_ptr<SimulatorInterface> &simulator_interface) const;
 
   private:
     enum class Comparison { GREATER_THAN, EQUAL_TO, LESS_THAN };

--- a/Sources/StreamdeckContext/ExportMonitors/IncrementMonitor.cpp
+++ b/Sources/StreamdeckContext/ExportMonitors/IncrementMonitor.cpp
@@ -20,11 +20,11 @@ void IncrementMonitor::update_settings(const json &settings)
     }
 }
 
-void IncrementMonitor::update(SimulatorInterface &simulator_interface)
+void IncrementMonitor::update(const std::unique_ptr<SimulatorInterface> &simulator_interface)
 {
     if (increment_monitor_is_set_) {
         const std::optional<Decimal> maybe_current_game_value =
-            simulator_interface.get_decimal_of_simulator_object_state(dcs_id_increment_monitor_);
+            simulator_interface->get_decimal_of_simulator_object_state(dcs_id_increment_monitor_);
         if (maybe_current_game_value.has_value()) {
             current_increment_value_ = maybe_current_game_value.value();
         }

--- a/Sources/StreamdeckContext/ExportMonitors/IncrementMonitor.h
+++ b/Sources/StreamdeckContext/ExportMonitors/IncrementMonitor.h
@@ -26,7 +26,7 @@ class IncrementMonitor
      *
      * @param simulator_interface Interface to request current game state from.
      */
-    void update(SimulatorInterface &simulator_interface);
+    void update(const std::unique_ptr<SimulatorInterface> &simulator_interface);
 
     /**
      * @brief Applies a commanded delta to the internal increment and returns the new current value.

--- a/Sources/StreamdeckContext/ExportMonitors/TitleMonitor.cpp
+++ b/Sources/StreamdeckContext/ExportMonitors/TitleMonitor.cpp
@@ -33,13 +33,13 @@ void TitleMonitor::update_settings(const json &settings)
     }
 }
 
-std::string TitleMonitor::determineTitle(SimulatorInterface &simulator_interface)
+std::string TitleMonitor::determineTitle(const std::unique_ptr<SimulatorInterface> &simulator_interface)
 {
     std::string updated_title = "";
 
     if (string_monitor_is_set_) {
         const std::optional<std::string> maybe_current_game_value =
-            simulator_interface.get_value_of_simulator_object_state(dcs_id_string_monitor_);
+            simulator_interface->get_value_of_simulator_object_state(dcs_id_string_monitor_);
         if (maybe_current_game_value.has_value()) {
             updated_title = convertGameStateToTitle(maybe_current_game_value.value());
         }

--- a/Sources/StreamdeckContext/ExportMonitors/TitleMonitor.h
+++ b/Sources/StreamdeckContext/ExportMonitors/TitleMonitor.h
@@ -26,7 +26,7 @@ class TitleMonitor
      * @param simulator_interface Interface to request current game state from.
      * @return The string that the Title should be set to if all settings are filled.
      */
-    std::string determineTitle(SimulatorInterface &simulator_interface);
+    std::string determineTitle(const std::unique_ptr<SimulatorInterface> &simulator_interface);
 
   private:
     /**
@@ -41,6 +41,6 @@ class TitleMonitor
     int dcs_id_string_monitor_ = 0;           // DCS ID to monitor for context title.
     int string_monitor_vertical_spacing_ = 0; // Vertical spacing (number of '\n') to include before or after title.
     bool string_monitor_passthrough_ = true;  // Flag set by user to passthrough string to title unaltered.
-    std::map<std::string, std::string>
+    std::unordered_map<std::string, std::string>
         string_monitor_mapping_; // Map of received values to title text to display on context.
 };

--- a/Sources/StreamdeckContext/ExportMonitors/test/IncrementMonitorTest.cpp
+++ b/Sources/StreamdeckContext/ExportMonitors/test/IncrementMonitorTest.cpp
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+#include "SimulatorInterface/SimulatorInterfaceFactory.h"
 #include "StreamdeckContext/ExportMonitors/IncrementMonitor.h"
 
 namespace test
@@ -57,9 +57,10 @@ class IncrementMonitorTestFixture : public ::testing::Test
 {
   public:
     IncrementMonitorTestFixture()
-        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
-          simulator_interface(connection_settings)
+        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port)
+
     {
+        simulator_interface = SimulatorInterfaceFactory(connection_settings, "DCS-ExportScript");
         // Consume intial reset command sent to to mock_dcs.
         (void)mock_dcs.receive();
     }
@@ -67,13 +68,13 @@ class IncrementMonitorTestFixture : public ::testing::Test
     void set_current_dcs_id_value(const std::string value)
     {
         mock_dcs.send("header*" + monitor_id_value + "=" + value);
-        simulator_interface.update_simulator_state();
+        simulator_interface->update_simulator_state();
     }
 
     std::string monitor_id_value = "123";
     SimulatorConnectionSettings connection_settings{"1908", "1909", "127.0.0.1"};
-    UdpSocket mock_dcs;                           // A socket that will mock Send/Receive messages from DCS.
-    DcsExportScriptInterface simulator_interface; // Simulator Interface to test.
+    UdpSocket mock_dcs;                                      // A socket that will mock Send/Receive messages from DCS.
+    std::unique_ptr<SimulatorInterface> simulator_interface; // Simulator Interface to test.
 };
 
 TEST_F(IncrementMonitorTestFixture, CurrentValueIsUpdatedFromDcsInterface)

--- a/Sources/StreamdeckContext/ExportMonitors/test/TitleMonitorTest.cpp
+++ b/Sources/StreamdeckContext/ExportMonitors/test/TitleMonitorTest.cpp
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+#include "SimulatorInterface/SimulatorInterfaceFactory.h"
 #include "StreamdeckContext/ExportMonitors/TitleMonitor.h"
 
 namespace test
@@ -12,9 +12,9 @@ class TitleMonitorTestFixture : public ::testing::Test
 {
   public:
     TitleMonitorTestFixture()
-        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
-          simulator_interface(connection_settings)
+        : mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port)
     {
+        simulator_interface = SimulatorInterfaceFactory(connection_settings, "DCS-ExportScript");
         // Consume intial reset command sent to to mock_dcs.
         (void)mock_dcs.receive();
     }
@@ -22,13 +22,13 @@ class TitleMonitorTestFixture : public ::testing::Test
     void set_current_dcs_id_value(const std::string value)
     {
         mock_dcs.send("header*" + monitor_id_value + "=" + value);
-        simulator_interface.update_simulator_state();
+        simulator_interface->update_simulator_state();
     }
 
     std::string monitor_id_value = "123";
     SimulatorConnectionSettings connection_settings{"1908", "1909", "127.0.0.1"};
-    UdpSocket mock_dcs;                           // A socket that will mock Send/Receive messages from DCS.
-    DcsExportScriptInterface simulator_interface; // Simulator Interface to test.
+    UdpSocket mock_dcs;                                      // A socket that will mock Send/Receive messages from DCS.
+    std::unique_ptr<SimulatorInterface> simulator_interface; // Simulator Interface to test.
 };
 
 TEST_F(TitleMonitorTestFixture, TitleUsesStringPassthrough)

--- a/Sources/StreamdeckContext/SendActions/IncrementContext.cpp
+++ b/Sources/StreamdeckContext/SendActions/IncrementContext.cpp
@@ -4,7 +4,7 @@
 
 #include "ElgatoSD/EPLJSONUtils.h"
 
-void IncrementContext::handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+void IncrementContext::handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                                 ESDConnectionManager *mConnectionManager,
                                                 const json &inPayload)
 {
@@ -14,12 +14,12 @@ void IncrementContext::handleButtonPressedEvent(SimulatorInterface &simulator_in
     if (is_integer(button_id) && is_integer(device_id)) {
         const auto send_command = determineSendValue(inPayload["settings"]);
         if (send_command) {
-            simulator_interface.send_simulator_command(std::stoi(button_id), device_id, send_command.value());
+            simulator_interface->send_simulator_command(std::stoi(button_id), device_id, send_command.value());
         }
     }
 }
 
-void IncrementContext::handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+void IncrementContext::handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                                  ESDConnectionManager *mConnectionManager,
                                                  const json &inPayload)
 {

--- a/Sources/StreamdeckContext/SendActions/IncrementContext.h
+++ b/Sources/StreamdeckContext/SendActions/IncrementContext.h
@@ -20,11 +20,11 @@ class IncrementContext : public StreamdeckContext
      * @param mConnectionManager Interface to StreamDeck.
      * @param payload Json payload received with KeyDown/KeyUp callback.
      */
-    void handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                   ESDConnectionManager *mConnectionManager,
                                   const json &inPayload);
 
-    void handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                    ESDConnectionManager *mConnectionManager,
                                    const json &inPayload);
 

--- a/Sources/StreamdeckContext/SendActions/MomentaryContext.cpp
+++ b/Sources/StreamdeckContext/SendActions/MomentaryContext.cpp
@@ -4,7 +4,7 @@
 
 #include "ElgatoSD/EPLJSONUtils.h"
 
-void MomentaryContext::handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+void MomentaryContext::handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                                 ESDConnectionManager *mConnectionManager,
                                                 const json &inPayload)
 {
@@ -13,11 +13,11 @@ void MomentaryContext::handleButtonPressedEvent(SimulatorInterface &simulator_in
     const auto send_command = EPLJSONUtils::GetStringByName(inPayload["settings"], "press_value");
 
     if (is_integer(button_id) && is_integer(device_id) && !send_command.empty()) {
-        simulator_interface.send_simulator_command(std::stoi(button_id), device_id, send_command);
+        simulator_interface->send_simulator_command(std::stoi(button_id), device_id, send_command);
     }
 }
 
-void MomentaryContext::handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+void MomentaryContext::handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                                  ESDConnectionManager *mConnectionManager,
                                                  const json &inPayload)
 {
@@ -32,6 +32,6 @@ void MomentaryContext::handleButtonReleasedEvent(SimulatorInterface &simulator_i
         EPLJSONUtils::GetBoolByName(inPayload["settings"], "disable_release_check");
 
     if (is_integer(button_id) && is_integer(device_id) && !send_command.empty() && !send_on_release_is_disabled) {
-        simulator_interface.send_simulator_command(std::stoi(button_id), device_id, send_command);
+        simulator_interface->send_simulator_command(std::stoi(button_id), device_id, send_command);
     }
 }

--- a/Sources/StreamdeckContext/SendActions/MomentaryContext.h
+++ b/Sources/StreamdeckContext/SendActions/MomentaryContext.h
@@ -19,11 +19,11 @@ class MomentaryContext : public StreamdeckContext
      * @param mConnectionManager Interface to Streamdeck for current context.
      * @param payload Json payload received with KeyDown/KeyUp callback.
      */
-    void handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                   ESDConnectionManager *mConnectionManager,
                                   const json &inPayload);
 
-    void handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                    ESDConnectionManager *mConnectionManager,
                                    const json &inPayload);
 };

--- a/Sources/StreamdeckContext/SendActions/SwitchContext.cpp
+++ b/Sources/StreamdeckContext/SendActions/SwitchContext.cpp
@@ -4,14 +4,14 @@
 
 #include "ElgatoSD/EPLJSONUtils.h"
 
-void SwitchContext::handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+void SwitchContext::handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                              ESDConnectionManager *mConnectionManager,
                                              const json &inPayload)
 {
     // Nothing sent to DCS on press.
 }
 
-void SwitchContext::handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+void SwitchContext::handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                               ESDConnectionManager *mConnectionManager,
                                               const json &inPayload)
 {
@@ -27,7 +27,7 @@ void SwitchContext::handleButtonReleasedEvent(SimulatorInterface &simulator_inte
         !send_when_second_state_value.empty()) {
 
         const auto send_value = is_first_state ? send_when_first_state_value : send_when_second_state_value;
-        simulator_interface.send_simulator_command(std::stoi(button_id), device_id, send_value);
+        simulator_interface->send_simulator_command(std::stoi(button_id), device_id, send_value);
     }
 
     // The Streamdeck will by default change a context's state after a KeyUp event, so a force send of the current

--- a/Sources/StreamdeckContext/SendActions/SwitchContext.h
+++ b/Sources/StreamdeckContext/SendActions/SwitchContext.h
@@ -20,11 +20,11 @@ class SwitchContext : public StreamdeckContext
      * @param mConnectionManager Interface to StreamDeck.
      * @param payload Json payload received with KeyDown/KeyUp callback.
      */
-    void handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                   ESDConnectionManager *mConnectionManager,
                                   const json &inPayload);
 
-    void handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+    void handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                    ESDConnectionManager *mConnectionManager,
                                    const json &inPayload);
 

--- a/Sources/StreamdeckContext/SendActions/test/MomentaryContextTest.cpp
+++ b/Sources/StreamdeckContext/SendActions/test/MomentaryContextTest.cpp
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+#include "SimulatorInterface/SimulatorInterfaceFactory.h"
 #include "StreamdeckContext/SendActions/MomentaryContext.h"
 
 #include "Test/MockESDConnectionManager.h"
@@ -16,7 +16,7 @@ class MomentaryContextKeyPressTestFixture : public ::testing::Test
     MomentaryContextKeyPressTestFixture()
         : // Mock DCS socket uses the reverse rx and tx ports of simulator_interface so it can communicate with it.
           mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
-          simulator_interface(connection_settings), fixture_context(fixture_context_id),
+          fixture_context(fixture_context_id),
           // Create default json payload.
           payload({{"state", 0},
                    {"settings",
@@ -26,12 +26,13 @@ class MomentaryContextKeyPressTestFixture : public ::testing::Test
                      {"release_value", release_value},
                      {"disable_release_check", false}}}})
     {
+        simulator_interface = SimulatorInterfaceFactory(connection_settings, "DCS-ExportScript");
         // Consume intial reset command sent to to mock_dcs.
         (void)mock_dcs.receive();
     }
     SimulatorConnectionSettings connection_settings = {"1928", "1929", "127.0.0.1"};
-    UdpSocket mock_dcs;                              // A socket that will mock Send/Receive messages from DCS.
-    DcsExportScriptInterface simulator_interface;    // Simulator Interface to test.
+    UdpSocket mock_dcs;                                      // A socket that will mock Send/Receive messages from DCS.
+    std::unique_ptr<SimulatorInterface> simulator_interface; // Simulator Interface to test.
     MockESDConnectionManager esd_connection_manager; // Streamdeck connection manager, using mock class definition.
     std::string fixture_context_id = "abc123";
     MomentaryContext fixture_context;

--- a/Sources/StreamdeckContext/SendActions/test/SwitchContextTest.cpp
+++ b/Sources/StreamdeckContext/SendActions/test/SwitchContextTest.cpp
@@ -4,7 +4,7 @@
 
 #include "StreamdeckContext/SendActions/SwitchContext.h"
 
-#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+#include "SimulatorInterface/SimulatorInterfaceFactory.h"
 #include "Test/MockESDConnectionManager.h"
 namespace test
 {
@@ -15,7 +15,7 @@ class SwitchContextKeyPressTestFixture : public ::testing::Test
     SwitchContextKeyPressTestFixture()
         : // Mock DCS socket uses the reverse rx and tx ports of simulator_interface so it can communicate with it.
           mock_dcs(connection_settings.ip_address, connection_settings.tx_port, connection_settings.rx_port),
-          simulator_interface(connection_settings), fixture_context(fixture_context_id),
+          fixture_context(fixture_context_id),
           // Create default json payload.
           payload({{"state", 0},
                    {"settings",
@@ -24,13 +24,14 @@ class SwitchContextKeyPressTestFixture : public ::testing::Test
                      {"send_when_first_state_value", send_when_first_state_value},
                      {"send_when_second_state_value", send_when_second_state_value}}}})
     {
+        simulator_interface = SimulatorInterfaceFactory(connection_settings, "DCS-ExportScript");
         // Consume intial reset command sent to to mock_dcs.
         (void)mock_dcs.receive();
     }
 
     SimulatorConnectionSettings connection_settings = {"1948", "1949", "127.0.0.1"};
-    UdpSocket mock_dcs;                              // A socket that will mock Send/Receive messages from DCS.
-    DcsExportScriptInterface simulator_interface;    // Simulator Interface to test.
+    UdpSocket mock_dcs;                                      // A socket that will mock Send/Receive messages from DCS.
+    std::unique_ptr<SimulatorInterface> simulator_interface; // Simulator Interface to test.
     MockESDConnectionManager esd_connection_manager; // Streamdeck connection manager, using mock class definition.
     std::string fixture_context_id = "abc123";
     SwitchContext fixture_context;

--- a/Sources/StreamdeckContext/StreamdeckContext.cpp
+++ b/Sources/StreamdeckContext/StreamdeckContext.cpp
@@ -11,7 +11,7 @@ StreamdeckContext::StreamdeckContext(const std::string &context, const json &set
     updateContextSettings(settings);
 }
 
-void StreamdeckContext::updateContextState(SimulatorInterface &simulator_interface,
+void StreamdeckContext::updateContextState(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                            ESDConnectionManager *mConnectionManager)
 {
 

--- a/Sources/StreamdeckContext/StreamdeckContext.h
+++ b/Sources/StreamdeckContext/StreamdeckContext.h
@@ -9,11 +9,9 @@
 #include "StreamdeckContext/ExportMonitors/TitleMonitor.h"
 #include "Utilities/StringUtilities.h"
 
+#include <memory>
 #include <optional>
 #include <string>
-
-enum class KeyEvent { PRESSED, RELEASED };
-enum class ContextState { FIRST, SECOND };
 
 class StreamdeckContext
 {
@@ -28,7 +26,8 @@ class StreamdeckContext
      * @param simulator_interface Interface to simulator containing current game state.
      * @param mConnectionManager Interface to StreamDeck.
      */
-    void updateContextState(SimulatorInterface &simulator_interface, ESDConnectionManager *mConnectionManager);
+    void updateContextState(const std::unique_ptr<SimulatorInterface> &simulator_interface,
+                            ESDConnectionManager *mConnectionManager);
 
     /**
      * @brief Forces an update to the Streamdeck of the context's current state be sent with current static values.
@@ -61,11 +60,11 @@ class StreamdeckContext
      * @param mConnectionManager Interface to StreamDeck.
      * @param payload Json payload received with KeyDown/KeyUp callback.
      */
-    virtual void handleButtonPressedEvent(SimulatorInterface &simulator_interface,
+    virtual void handleButtonPressedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                           ESDConnectionManager *mConnectionManager,
                                           const json &inPayload){};
 
-    virtual void handleButtonReleasedEvent(SimulatorInterface &simulator_interface,
+    virtual void handleButtonReleasedEvent(const std::unique_ptr<SimulatorInterface> &simulator_interface,
                                            ESDConnectionManager *mConnectionManager,
                                            const json &inPayload){};
 

--- a/Sources/StreamdeckContext/StreamdeckContextFactory.cpp
+++ b/Sources/StreamdeckContext/StreamdeckContextFactory.cpp
@@ -22,11 +22,11 @@ StreamdeckContextFactory::create(const std::string &action_uuid, const std::stri
 {
     switch (button_action_from_uuid_[action_uuid]) {
     case ButtonAction::MOMENTARY:
-        return std::unique_ptr<StreamdeckContext>(new MomentaryContext(context, settings));
+        return std::make_unique<MomentaryContext>(context, settings);
     case ButtonAction::INCREMENT:
-        return std::unique_ptr<StreamdeckContext>(new IncrementContext(context, settings));
+        return std::make_unique<IncrementContext>(context, settings);
     case ButtonAction::SWITCH:
-        return std::unique_ptr<StreamdeckContext>(new SwitchContext(context, settings));
+        return std::make_unique<SwitchContext>(context, settings);
     default:
         return NULL;
     }

--- a/Sources/StreamdeckInterface/StreamdeckInterface.h
+++ b/Sources/StreamdeckInterface/StreamdeckInterface.h
@@ -11,9 +11,10 @@
 //==============================================================================
 
 #include "ElgatoSD/ESDBasePlugin.h"
-#include "SimulatorInterface/Backends/DcsExportScriptInterface.h"
+#include "SimulatorInterface/SimulatorInterface.h"
 #include "StreamdeckContext/StreamdeckContextFactory.h"
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 
@@ -77,6 +78,6 @@ class StreamdeckInterface : public ESDBasePlugin
     std::unordered_map<std::string, std::unique_ptr<StreamdeckContext>> mVisibleContexts = {};
 
     CallBackTimer *mTimer;
-    std::optional<DcsExportScriptInterface> simulator_interface_ = std::nullopt;
+    std::unique_ptr<SimulatorInterface> simulator_interface_;
     StreamdeckContextFactory streamdeck_context_factory;
 };


### PR DESCRIPTION
This is a follow-on PR that modifies all uses of SimulatorInterface to use it as a pointer so different backends can be used easily in the future.

Supports #41 