### PR TITLE
Add DCS Bios protocol parser

### DIFF
--- a/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.cpp
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.cpp
@@ -1,0 +1,91 @@
+// Copyright 2021 Charles Tytler, modified from "ExportStreamParser":
+/*
+    Copyright 2015 Craig Courtney
+    This file is part of DcsBios-Firmware.
+    DcsBios-Firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    DcsBios-Firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with DcsBios-Firmware.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DcsBiosStreamParser.h"
+
+DcsBiosStreamParser::DcsBiosStreamParser()
+{
+    _state = DcsBiosState::WAIT_FOR_SYNC;
+    _sync_byte_count = 0;
+}
+
+void DcsBiosStreamParser::processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address)
+{
+    switch (_state) {
+    case DcsBiosState::WAIT_FOR_SYNC:
+        /* do nothing */
+        break;
+
+    case DcsBiosState::ADDRESS_LOW:
+        _address = (unsigned int)c;
+        _state = DcsBiosState::ADDRESS_HIGH;
+        break;
+
+    case DcsBiosState::ADDRESS_HIGH:
+        _address = (c << 8u) | _address;
+        if (_address != 0x5555) {
+            _state = DcsBiosState::COUNT_LOW;
+        } else {
+            _state = DcsBiosState::WAIT_FOR_SYNC;
+        }
+        break;
+
+    case DcsBiosState::COUNT_LOW:
+        _count = (unsigned int)c;
+        _state = DcsBiosState::COUNT_HIGH;
+        break;
+
+    case DcsBiosState::COUNT_HIGH:
+        _count = (c << 8u) | _count;
+        _state = DcsBiosState::DATA_LOW;
+        break;
+
+    case DcsBiosState::DATA_LOW:
+        _data = (unsigned int)c;
+        _count--;
+        _state = DcsBiosState::DATA_HIGH;
+        break;
+
+    case DcsBiosState::DATA_HIGH:
+        _data = (c << 8u) | _data;
+        _count--;
+        data_by_address[_address] = _data;
+        if (_count == 0) {
+            _state = DcsBiosState::ADDRESS_LOW;
+
+            // Frame sync moved to end of frame.  All time consuming updates should
+            // be handled in framesync during the down time between frame transmissions.
+            // if (_address == 0xfffe) {
+            //     // Perform operation if desired here.
+            // }
+        } else {
+            _address += 2;
+            _state = DcsBiosState::DATA_LOW;
+        }
+        break;
+    }
+
+    if (c == 0x55) {
+        _sync_byte_count++;
+    } else {
+        _sync_byte_count = 0;
+    }
+
+    if (_sync_byte_count == 4) {
+        _state = DcsBiosState::ADDRESS_LOW;
+        _sync_byte_count = 0;
+    }
+}

--- a/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.cpp
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.cpp
@@ -22,8 +22,10 @@ DcsBiosStreamParser::DcsBiosStreamParser()
     _sync_byte_count = 0;
 }
 
-void DcsBiosStreamParser::processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address)
+bool DcsBiosStreamParser::processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address)
 {
+    bool end_of_frame_sync_received = false;
+
     switch (_state) {
     case DcsBiosState::WAIT_FOR_SYNC:
         /* do nothing */
@@ -66,11 +68,11 @@ void DcsBiosStreamParser::processByte(uint8_t c, std::unordered_map<unsigned int
         if (_count == 0) {
             _state = DcsBiosState::ADDRESS_LOW;
 
-            // Frame sync moved to end of frame.  All time consuming updates should
+            // Frame sync moved to end of frame.All time consuming updates should
             // be handled in framesync during the down time between frame transmissions.
-            // if (_address == 0xfffe) {
-            //     // Perform operation if desired here.
-            // }
+            if (_address == 0xfffe) {
+                end_of_frame_sync_received = true;
+            }
         } else {
             _address += 2;
             _state = DcsBiosState::DATA_LOW;
@@ -88,4 +90,6 @@ void DcsBiosStreamParser::processByte(uint8_t c, std::unordered_map<unsigned int
         _state = DcsBiosState::ADDRESS_LOW;
         _sync_byte_count = 0;
     }
+
+    return end_of_frame_sync_received;
 }

--- a/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.h
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.h
@@ -1,0 +1,41 @@
+// Copyright 2021 Charles Tytler, modified from "ExportStreamParser":
+/*
+    Copyright 2015 Craig Courtney
+    This file is part of DcsBios-Firmware.
+    DcsBios-Firmware is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    DcsBios-Firmware is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with DcsBios-Firmware.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <unordered_map>
+
+class DcsBiosStreamParser
+{
+  public:
+    DcsBiosStreamParser();
+
+    /**
+     * @brief Processes a single byte from the export stream at a time, populating data by address.
+     * @param Single byte of DCS BIOS export stream.
+     * @param Map to populate data by address when full address contents are received.
+     */
+    void processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address);
+
+  private:
+    // State machine states for parsing protocol.
+    enum class DcsBiosState { WAIT_FOR_SYNC, ADDRESS_LOW, ADDRESS_HIGH, COUNT_LOW, COUNT_HIGH, DATA_LOW, DATA_HIGH };
+    DcsBiosState _state;
+    unsigned int _address;
+    unsigned int _count;
+    unsigned int _data;
+    unsigned char _sync_byte_count;
+};

--- a/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.h
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/DcsBiosStreamParser.h
@@ -26,9 +26,10 @@ class DcsBiosStreamParser
     /**
      * @brief Processes a single byte from the export stream at a time, populating data by address.
      * @param Single byte of DCS BIOS export stream.
-     * @param Map to populate data by address when full address contents are received.
+     * @param Map to populate data by address as full address contents are received.
+     * @return End of frame flag, true if address 0xFFFE is received.
      */
-    void processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address);
+    bool processByte(uint8_t c, std::unordered_map<unsigned int, unsigned int> &data_by_address);
 
   private:
     // State machine states for parsing protocol.

--- a/Sources/backend-cpp/SimulatorInterface/Protocols/test/DcsBiosStreamParserTest.cpp
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/test/DcsBiosStreamParserTest.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021 Charles Tytler
+
+#include "gtest/gtest.h"
+
+#include "SimulatorInterface/Protocols/DcsBiosStreamParser.h"
+
+namespace test
+{
+#define SIZE_OF(x) (sizeof(x) / sizeof((x)[0]))
+
+TEST(DcsBiosStreamParserTest, ReadSampleDataStream)
+{
+    const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,                         // Sync frame
+                                  0x08, 0x00, 0x02, 0x00, 0x6F, 0x72,             // Addr 0x0008 (2 bytes)
+                                  0x02, 0x04, 0x04, 0x00, 0x31, 0x30, 0x2E, 0x30, // Addr 0x0402 (4 bytes)
+                                  0x0C, 0x74, 0x02, 0x00, 0x00, 0x02};            // Addr 0x740C (2 bytes)
+    std::unordered_map<unsigned int, unsigned int> data_by_address;
+    DcsBiosStreamParser parser;
+    for (int i = 0; i < SIZE_OF(sample_stream); i++) {
+        parser.processByte(sample_stream[i], data_by_address);
+    }
+    // Expect 4 address locations, since DCS BIOS groups data into 16-bit (2 bytes) chunks at each address.
+    EXPECT_EQ(data_by_address.size(), 4);
+    EXPECT_EQ(data_by_address[0x0008], 0x726F);
+    EXPECT_EQ(data_by_address[0x0402], 0x3031); // Note that 4 bytes gets split into two 16-bit addresses
+    EXPECT_EQ(data_by_address[0x0404], 0x302E);
+    EXPECT_EQ(data_by_address[0x740C], 0x0200);
+}
+
+TEST(DcsBiosStreamParserTest, HandleEmptyDataStream)
+{
+    // clang-format off
+    const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,              // Sync frame
+                                  0x55, 0x55, 0x55, 0x55,              // Another Sync frame
+                                  0x02, 0x04, 0x02, 0x00, 0x31, 0x30}; // Addr 0x0402 (2 bytes)
+    // clang-format on
+    std::unordered_map<unsigned int, unsigned int> data_by_address;
+    DcsBiosStreamParser parser;
+    for (int i = 0; i < SIZE_OF(sample_stream); i++) {
+        parser.processByte(sample_stream[i], data_by_address);
+    }
+    // Expect parser to handle multiple sync frames (and not set anything to address 0x5555).
+    EXPECT_EQ(data_by_address.size(), 1);
+    EXPECT_EQ(data_by_address[0x0402], 0x3031);
+}
+
+TEST(DcsBiosStreamParserTest, ReadInteruptedDataStream)
+{
+    // clang-format off
+    const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,              // Sync frame
+                                  0x08, 0x00, 0x02,                    // Cut-off frame
+                                  0x55, 0x55, 0x55, 0x55,              // Another Sync frame
+                                  0x02, 0x04, 0x02, 0x00, 0x31, 0x30}; // Addr 0x0402 (2 bytes)
+    // clang-format on
+    std::unordered_map<unsigned int, unsigned int> data_by_address;
+    DcsBiosStreamParser parser;
+    for (int i = 0; i < SIZE_OF(sample_stream); i++) {
+        parser.processByte(sample_stream[i], data_by_address);
+    }
+    // Expect parser to still see 2 addresses.
+    EXPECT_EQ(data_by_address.size(), 2);
+    EXPECT_EQ(data_by_address[0x0008], 0x5555); // Note this reads some of the next sync frame as data into 0x008
+    EXPECT_EQ(data_by_address[0x0402], 0x3031); // But successfully reads the next data address
+}
+} // namespace test

--- a/Sources/backend-cpp/SimulatorInterface/Protocols/test/DcsBiosStreamParserTest.cpp
+++ b/Sources/backend-cpp/SimulatorInterface/Protocols/test/DcsBiosStreamParserTest.cpp
@@ -10,21 +10,26 @@ namespace test
 
 TEST(DcsBiosStreamParserTest, ReadSampleDataStream)
 {
-    const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,                         // Sync frame
-                                  0x08, 0x00, 0x02, 0x00, 0x6F, 0x72,             // Addr 0x0008 (2 bytes)
-                                  0x02, 0x04, 0x04, 0x00, 0x31, 0x30, 0x2E, 0x30, // Addr 0x0402 (4 bytes)
-                                  0x0C, 0x74, 0x02, 0x00, 0x00, 0x02};            // Addr 0x740C (2 bytes)
+    const char sample_stream[] = {0x55,       0x55,       0x55, 0x55,                         // Sync frame
+                                  0x08,       0x00,       0x02, 0x00, 0x6F, 0x72,             // Addr 0x0008 (2 bytes)
+                                  0x02,       0x04,       0x04, 0x00, 0x31, 0x30, 0x2E, 0x30, // Addr 0x0402 (4 bytes)
+                                  0x0C,       0x74,       0x02, 0x00, 0x00, 0x02,             // Addr 0x740C (2 bytes)
+                                  (char)0xFE, (char)0xFF, 0x02, 0x00, 0x00, 0x00};            // End of frame
     std::unordered_map<unsigned int, unsigned int> data_by_address;
     DcsBiosStreamParser parser;
+    bool is_end_of_frame = false;
     for (int i = 0; i < SIZE_OF(sample_stream); i++) {
-        parser.processByte(sample_stream[i], data_by_address);
+        EXPECT_FALSE(is_end_of_frame);
+        is_end_of_frame = parser.processByte(sample_stream[i], data_by_address);
     }
-    // Expect 4 address locations, since DCS BIOS groups data into 16-bit (2 bytes) chunks at each address.
-    EXPECT_EQ(data_by_address.size(), 4);
+    EXPECT_TRUE(is_end_of_frame);
+    // Expect 5 address locations, since DCS BIOS groups data into 16-bit (2 bytes) chunks at each address.
+    EXPECT_EQ(data_by_address.size(), 5);
     EXPECT_EQ(data_by_address[0x0008], 0x726F);
     EXPECT_EQ(data_by_address[0x0402], 0x3031); // Note that 4 bytes gets split into two 16-bit addresses
     EXPECT_EQ(data_by_address[0x0404], 0x302E);
     EXPECT_EQ(data_by_address[0x740C], 0x0200);
+    EXPECT_EQ(data_by_address[0xFFFE], 0x0000);
 }
 
 TEST(DcsBiosStreamParserTest, HandleEmptyDataStream)
@@ -32,19 +37,46 @@ TEST(DcsBiosStreamParserTest, HandleEmptyDataStream)
     // clang-format off
     const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,              // Sync frame
                                   0x55, 0x55, 0x55, 0x55,              // Another Sync frame
-                                  0x02, 0x04, 0x02, 0x00, 0x31, 0x30}; // Addr 0x0402 (2 bytes)
+                                  0x02, 0x04, 0x02, 0x00, 0x31, 0x30,  // Addr 0x0402 (2 bytes)
+                                  (char)0xFE, (char)0xFF, 0x02, 0x00, 0x00, 0x00}; // End of frame
     // clang-format on
     std::unordered_map<unsigned int, unsigned int> data_by_address;
     DcsBiosStreamParser parser;
+    bool is_end_of_frame = false;
     for (int i = 0; i < SIZE_OF(sample_stream); i++) {
-        parser.processByte(sample_stream[i], data_by_address);
+        EXPECT_FALSE(is_end_of_frame);
+        is_end_of_frame = parser.processByte(sample_stream[i], data_by_address);
     }
+    EXPECT_TRUE(is_end_of_frame);
     // Expect parser to handle multiple sync frames (and not set anything to address 0x5555).
-    EXPECT_EQ(data_by_address.size(), 1);
+    EXPECT_EQ(data_by_address.size(), 2);
     EXPECT_EQ(data_by_address[0x0402], 0x3031);
+    EXPECT_EQ(data_by_address[0xFFFE], 0x0000);
 }
 
 TEST(DcsBiosStreamParserTest, ReadInteruptedDataStream)
+{
+    const char sample_stream[] = {0x55,       0x55,       0x55, 0x55,              // Sync frame
+                                  0x08,       0x00,       0x02,                    // Cut-off frame
+                                  0x55,       0x55,       0x55, 0x55,              // Another Sync frame
+                                  0x02,       0x04,       0x02, 0x00, 0x31, 0x30,  // Addr 0x0402 (2 bytes)
+                                  (char)0xFE, (char)0xFF, 0x02, 0x00, 0x00, 0x00}; // End of frame
+    std::unordered_map<unsigned int, unsigned int> data_by_address;
+    DcsBiosStreamParser parser;
+    bool is_end_of_frame = false;
+    for (int i = 0; i < SIZE_OF(sample_stream); i++) {
+        EXPECT_FALSE(is_end_of_frame);
+        is_end_of_frame = parser.processByte(sample_stream[i], data_by_address);
+    }
+    EXPECT_TRUE(is_end_of_frame);
+    // Expect parser to still see 2 addresses.
+    EXPECT_EQ(data_by_address.size(), 3);
+    EXPECT_EQ(data_by_address[0x0008], 0x5555); // Note this reads some of the next sync frame as data into 0x008
+    EXPECT_EQ(data_by_address[0x0402], 0x3031); // But successfully reads the next data address
+    EXPECT_EQ(data_by_address[0xFFFE], 0x0000);
+}
+
+TEST(DcsBiosStreamParserTest, ReadDataStreamWithoutEndOfFrame)
 {
     // clang-format off
     const char sample_stream[] = {0x55, 0x55, 0x55, 0x55,              // Sync frame
@@ -55,7 +87,8 @@ TEST(DcsBiosStreamParserTest, ReadInteruptedDataStream)
     std::unordered_map<unsigned int, unsigned int> data_by_address;
     DcsBiosStreamParser parser;
     for (int i = 0; i < SIZE_OF(sample_stream); i++) {
-        parser.processByte(sample_stream[i], data_by_address);
+        bool is_end_of_frame = parser.processByte(sample_stream[i], data_by_address);
+        EXPECT_FALSE(is_end_of_frame);
     }
     // Expect parser to still see 2 addresses.
     EXPECT_EQ(data_by_address.size(), 2);


### PR DESCRIPTION
Add a parser of DCS BIOS messages based off the C code within `dcs-bios-arduino`
Supports #41 